### PR TITLE
Re-word description of open() in standard library reference to include fopen-like syntax

### DIFF
--- a/manual/standard-library-reference/index.md
+++ b/manual/standard-library-reference/index.md
@@ -246,7 +246,18 @@ Fully implemented by: `Vector` (aka 1-d `Array`).
 
 `stdin_stream` — Global variable referring to the standard input stream.
 
-`open(file_name[, read, write, create, truncate, append])` — Open a file in a mode specified by four boolean arguments. The default is to open files for reading only.
+`open(file_name[, read, write, create, truncate, append])` — Open a file in a mode specified by five boolean arguments. The default is to open files for reading only. Returns a stream for accessing the file.
+
+`open(file_name[, mode])` - Alternate syntax for open, where a string-based mode specifier is used instead of the five booleans. The values of `mode` correspond to those from `fopen(3)` or Perl `open`, and are equivalent to setting the following boolean groups:
+
+<table>
+<tr><td>"r"</td><td>read</td></tr>
+<tr><td>"r+"</td><td>read, write</td></tr>
+<tr><td>"w"</td><td>write, create, truncate</td></tr>
+<tr><td>"w+"</td><td>read, write, create, truncate</td></tr>
+<tr><td>"a"</td><td>write, create, append</td></tr>
+<tr><td>"a+"</td><td>read, write, create, append</td></tr>
+</table>
 
 `memio([size])` — Create an in-memory I/O stream, optionally specifying how much initial space is needed.
 


### PR DESCRIPTION
The current description of open() in the standard library reference only lists the version using five boolean arguments (and says there are four). 

I fixed the count, and added a description of the fopen-like syntax where a mode String is used in place of the booleans. A table is included which shows the mapping between mode String and booleans.

The HTML syntax for tables is not pretty in the nice Markdown doc :P, but it is the recommended syntax from the [official docs](http://daringfireball.net/projects/markdown/syntax)
