### PR TITLE
Update target links in manual after file extension change

### DIFF
--- a/manual/calling-c-and-fortran-code/index.md
+++ b/manual/calling-c-and-fortran-code/index.md
@@ -68,7 +68,7 @@ This is because `(Ptr{Uint8})` is just `Ptr{Uint8}`, rather than a 1-tuple conta
 
 In practice, especially when providing reusable functionality, one generally wraps `ccall` usages in Julia functions that set up arguments and then check for errors in whatever manner the C or Fortran function indicates them, propagating to the Julia caller as exceptions.
 This is especially important since C and Fortran APIs are notoriously inconsistent about how they indicate error conditions.
-For example, the `getenv` C library function is wrapped in the following Julia function in [`env.jl`](https://github.com/JuliaLang/julia/blob/master/j/env.jl):
+For example, the `getenv` C library function is wrapped in the following Julia function in [`env.jl`](https://github.com/JuliaLang/julia/blob/master/jl/env.jl):
 
     function getenv(var::String)
       val = ccall(dlsym(libc, :getenv),

--- a/manual/constructors/index.md
+++ b/manual/constructors/index.md
@@ -124,11 +124,11 @@ The following two types are equivalent — one with a default constructor, the 
 
     julia> T1(1.0)
     no method T1(Float64,)
-     in method_missing at /Users/stefan/projects/julia/j/base.jl:58
+     in method_missing at /Users/stefan/projects/julia/jl/base.jl:58
 
     julia> T2(1.0)
     no method T2(Float64,)
-     in method_missing at /Users/stefan/projects/julia/j/base.jl:58
+     in method_missing at /Users/stefan/projects/julia/jl/base.jl:58
 
 It is considered good form to provide as few inner constructor methods as possible:
 only those taking all arguments explicitly and enforcing essential error checking and transformation.
@@ -224,7 +224,7 @@ Here are some examples:
 
     julia> Point(1,2.5)
     no method Point(Int64,Float64)
-     in method_missing at /Users/stefan/projects/julia/j/base.jl:58
+     in method_missing at /Users/stefan/projects/julia/jl/base.jl:58
 
     ## explicit T ##
 
@@ -233,14 +233,14 @@ Here are some examples:
 
     julia> Point{Int64}(1.0,2.5)
     no method Point(Float64,Float64)
-     in method_missing at /Users/stefan/projects/julia/j/base.jl:58
+     in method_missing at /Users/stefan/projects/julia/jl/base.jl:58
 
     julia> Point{Float64}(1.0,2.5)
     Point(1.0,2.5)
 
     julia> Point{Float64}(1,2)
     no method Point(Int64,Int64)
-     in method_missing at /Users/stefan/projects/julia/j/base.jl:58
+     in method_missing at /Users/stefan/projects/julia/jl/base.jl:58
 
 As you can see, for constructor calls with explicit type parameters, the arguments must match that specific type:
 `Point{Int64}(1,2)` works, but `Point{Int64}(1.0,2.5)` does not.
@@ -312,7 +312,7 @@ Moreover, since constructors can leverage all of the power of the type system, m
 ## Case Study: Rational
 
 Perhaps the best way to tie all these pieces together is to present a real world example of a parametric composite type and its constructor methods.
-To that end, here is beginning of [`rational.jl`](https://github.com/JuliaLang/julia/blob/master/j/rational.jl), which implements Julia's [rational numbers](../complex-and-rational-numbers#Rational+Numbers):
+To that end, here is beginning of [`rational.jl`](https://github.com/JuliaLang/julia/blob/master/jl/rational.jl), which implements Julia's [rational numbers](../complex-and-rational-numbers#Rational+Numbers):
 
     type Rational{T<:Integer} <: Real
         num::T
@@ -377,5 +377,5 @@ Finally, applying `//` to complex integral values creates an instance of `Comple
     true
 
 Thus, although the `//` operator usually returns an instance of `Rational`, if either of its arguments are complex integers, it will return an instance of `Complex{Rational}` instead.
-The interested reader should consider perusing the rest of [`rational.jl`](https://github.com/JuliaLang/julia/blob/master/j/rational.jl):
+The interested reader should consider perusing the rest of [`rational.jl`](https://github.com/JuliaLang/julia/blob/master/jl/rational.jl):
 it is short, self-contained, and implements an entire basic Julia type in just a little over a hundred lines of code.

--- a/manual/conversion-and-promotion/index.md
+++ b/manual/conversion-and-promotion/index.md
@@ -91,7 +91,7 @@ The method signatures for conversion methods are often quite a bit more involved
 
 ### Case Study: Rational Conversions
 
-To continue our case study of Julia's `Rational` type, here are the conversions declared in [`rational.jl`](https://github.com/JuliaLang/julia/blob/master/j/rational.jl), right after the declaration of the type and its constructors:
+To continue our case study of Julia's `Rational` type, here are the conversions declared in [`rational.jl`](https://github.com/JuliaLang/julia/blob/master/jl/rational.jl), right after the declaration of the type and its constructors:
 
     convert{T<:Int}(::Type{Rational{T}}, x::Rational) = Rational(convert(T,x.num),convert(T,x.den))
     convert{T<:Int}(::Type{Rational{T}}, x::Int) = Rational(convert(T,x), convert(T,1))
@@ -165,7 +165,7 @@ Complex values mixed with real values are promoted to the appropriate kind of co
 
 That is really all there is to using promotions.
 The rest is just a matter of clever application, the most typical "clever" application being the definition of catch-all methods for numeric operations like the arithmetic operators `+`, `-`, `*` and `/`.
-Here are some of the the catch-all method definitions given in [`promotion.jl`](https://github.com/JuliaLang/julia/blob/master/j/promotion.jl):
+Here are some of the the catch-all method definitions given in [`promotion.jl`](https://github.com/JuliaLang/julia/blob/master/jl/promotion.jl):
 
     +(x::Number, y::Number) = +(promote(x,y)...)
     -(x::Number, y::Number) = -(promote(x,y)...)
@@ -175,9 +175,9 @@ Here are some of the the catch-all method definitions given in [`promotion.jl`](
 These method definitions say that in the absence of more specific rules for adding, subtracting, multiplying and dividing pairs of numeric values, promote the values to a common type and then try again.
 That's all there is to it:
 nowhere else does one ever need to worry about promotion to a common numeric type for arithmetic operations — it just happens automatically.
-There are definitions of catch-all promotion methods for a number of other arithmetic and mathematical functions in [`promotion.jl`](https://github.com/JuliaLang/julia/blob/master/j/promotion.jl), but beyond that, there are hardly any calls to `promote` required in the Julia standard library.
+There are definitions of catch-all promotion methods for a number of other arithmetic and mathematical functions in [`promotion.jl`](https://github.com/JuliaLang/julia/blob/master/jl/promotion.jl), but beyond that, there are hardly any calls to `promote` required in the Julia standard library.
 The most common usages of `promote` occur in outer constructors methods, provided for convenience, to allow constructor calls with mixed types to delegate to an inner type with fields promoted to an appropriate common type.
-For example, recall that [`rational.jl`](https://github.com/JuliaLang/julia/blob/master/j/rational.jl) provides the following outer constructor method:
+For example, recall that [`rational.jl`](https://github.com/JuliaLang/julia/blob/master/jl/rational.jl) provides the following outer constructor method:
 
     Rational(n::Int, d::Int) = Rational(promote(n,d)...)
 
@@ -219,7 +219,7 @@ Thus, if one wants to know, in absence of actual values, what type a collection 
 
 Internally, `promote_type` is used inside of `promote` to determine what type argument values should be converted to for promotion.
 It can, however, be useful in its own right.
-The curious reader can read the code in [`promotion.jl`](https://github.com/JuliaLang/julia/blob/master/j/promotion.jl), which defines the complete promotion mechanism in about 35 lines.
+The curious reader can read the code in [`promotion.jl`](https://github.com/JuliaLang/julia/blob/master/jl/promotion.jl), which defines the complete promotion mechanism in about 35 lines.
 
 ### Case Study: Rational Promotions
 

--- a/manual/metaprogramming/index.md
+++ b/manual/metaprogramming/index.md
@@ -208,7 +208,7 @@ Before the program runs, this statement will be replaced with the result of call
         ...
     end
 
-Here, for example, is very nearly the definition of Julia's `@assert` macro (see [`error.jl`](https://github.com/JuliaLang/julia/blob/master/j/error.jl) for the actual definition, which allows `@assert` to work on booleans arrays as well):
+Here, for example, is very nearly the definition of Julia's `@assert` macro (see [`error.jl`](https://github.com/JuliaLang/julia/blob/master/jl/error.jl) for the actual definition, which allows `@assert` to work on booleans arrays as well):
 
     macro assert(ex)
         :($ex ? nothing : error("Assertion failed: ", $string(ex)))

--- a/manual/performance-tips/index.md
+++ b/manual/performance-tips/index.md
@@ -112,6 +112,6 @@ Julia's compiler specializes code for argument types at function boundaries, so 
 
 The second form is also often better style and can lead to more code reuse.
 
-This pattern is used in several places in the standard library. For example, see `_jl_hvcat_fill` in `abstractarray.jl`, or the `fill!` function, which we could have used instead of writing our own `fill_twos!`.
+This pattern is used in several places in the standard library. For example, see `_jl_hvcat_fill` in [`abstractarray.jl`](https://github.com/JuliaLang/julia/blob/master/jl/abstractarray.jl), or the `fill!` function, which we could have used instead of writing our own `fill_twos!`.
 
 Functions like `strange_twos` occur when dealing with data of uncertain type, for example data loaded from an input file that might contain either integers, floats, strings, or something else.


### PR DESCRIPTION
Subdirectory name in URL change to 'jl' from 'j'.

Due to Julia file extension change, links to standard lib files in manual are all broken as a result of outdated subdirectory name in URL.
