### PR TITLE
Fix 404 to package list

### DIFF
--- a/teaching/index.md
+++ b/teaching/index.md
@@ -15,7 +15,7 @@ The [Julia manual](http://docs.julialang.org/en/latest/) contains a complete int
 
 # Julia packages for teaching
 
-Julia [packages](http://docs.julialang.org/en/latest/packages/packagelist.html) span a number of disciplines. Some packages are well developed, whereas others are fledgling efforts.
+Julia [packages](http://docs.julialang.org/en/latest/packages/packagelist/) span a number of disciplines. Some packages are well developed, whereas others are fledgling efforts.
 
 # Videos
 


### PR DESCRIPTION
On the _teaching_ page of Julia homepage, the link to the package list lead to a 404.
This fixes the link to the package list.
