### PR TITLE
Update index.md

### DIFF
--- a/downloads/index.md
+++ b/downloads/index.md
@@ -22,7 +22,7 @@ Current version: [release **v0.1.2**](http://code.google.com/p/julialang/downloa
 </tr>
 <tr>
     <th> Source (Git) </th>
-    <td colspan=2> <a href="https://github.com/JuliaLang/julia/tree/release-0.1">git@github.com:JuliaLang/julia -b release0.1</a> </td>
+    <td colspan=2> <a href="https://github.com/JuliaLang/julia/tree/v0.1.2">git@github.com:JuliaLang/julia -b 'v0.1.2'</a> </td>
 </tr>
 </tbody></table>
 


### PR DESCRIPTION
Maybe I'm a fool, but the tag/branch release0.1 doesn't seem to exist when I try to clone.

```
danking@beverly # git clone git@github.com:JuliaLang/julia.git -b 'release0.1' julia-0.1
Cloning into 'julia-0.1'...
Enter passphrase for key '/home/danking/.ssh/id_rsa': 
fatal: Remote branch release0.1 not found in upstream origin
```

I, however, can check out the tag for v0.1.2. Is this the intended tag? This pull request updates the downloads page to use the v0.1.2 tag instead of release0.1.
