### PR TITLE
Update optimization links to point to JuliaOpt

### DIFF
--- a/blog/_posts/2013-03-30-julia-tutorial-MIT.md
+++ b/blog/_posts/2013-03-30-julia-tutorial-MIT.md
@@ -39,7 +39,7 @@ Julia provides a built-in interface to the [FFTW](http://www.fftw.org/) library.
 
 ## Optimization ([slides](https://github.com/JuliaLang/julia-tutorial/raw/master/NumericalOptimization/presentation.pdf))
 
-This session focuses largely on using Julia for solving linear programming problems. The algebraic modeling language discussed was later released as [JuMP](https://github.com/IainNZ/JuMP.jl). Benchmarks are shown evaluating the performance of Julia for implementing low-level optimization code. Linear programming solvers are available through the [CLP](https://github.com/mlubin/Clp.jl), [GLPK](https://github.com/carlobaldassi/GLPK.jl), and [Gurobi](https://github.com/lindahua/Gurobi.jl) packages. The [Optim](https://github.com/johnmyleswhite/Optim.jl) and [NLopt](https://github.com/stevengj/NLopt.jl) packages provide more general optimization algorithms.
+This session focuses largely on using Julia for solving linear programming problems. The algebraic modeling language discussed was later released as [JuMP](https://github.com/IainNZ/JuMP.jl). Benchmarks are shown evaluating the performance of Julia for implementing low-level optimization code. Optimization software in Julia has been grouped under the [JuliaOpt](http://juliaopt.org/) project.
 
 <iframe width="560" height="315" src="http://www.youtube.com/embed/O1icUP6sajU" frameborder="0" allowfullscreen></iframe>
 

--- a/blog/_posts/2013-04-05-distributed-numerical-optimization.md
+++ b/blog/_posts/2013-04-05-distributed-numerical-optimization.md
@@ -45,10 +45,8 @@ candidate \\( x \\) be the minimizer of \\( \sum_{i=1}&#94;n m_i(x) \\).
 If it is costly to evaluate \\( f_i(x) \\), then the algorithm is naturally
 parallelizable at step 2. The minimization in step 3 can be computed by solving
 a linear optimization problem, which is usually very fast. (Let me point out
-here that Julia has interfaces to the linear programming solvers <a
-href="https://github.com/mlubin/Clp.jl">Clp</a>, <a
-href="https://github.com/lindahua/Gurobi.jl">Gurobi</a>, and <a
-href="https://github.com/carlobaldassi/GLPK.jl">GLPK</a>.)
+here that Julia has interfaces to linear programming and other
+optimization solvers under <a href="http://juliaopt.org/">JuliaOpt</a>.)
 
 Abstracting the math, we can write the algorithm using the following Julia code. 
 


### PR DESCRIPTION
This removes some old links and points everyone to JuliaOpt.
