### PR TITLE
Add julia-deps PPA for Ubuntu install

### DIFF
--- a/downloads/index.md
+++ b/downloads/index.md
@@ -80,6 +80,7 @@ Instructions will be added here as more linux distributions start including juli
 ### Ubuntu
 A [PPA](https://launchpad.net/~staticfloat/+archive/juliareleases) (Personal Package Archive) is provided for Ubuntu systems to allow for automatic updating to the latest stable version of Julia.  To use this PPA and install julia on Ubuntu 12.04 or later, simply type:
 
+    $ sudo add-apt-repository ppa:staticfloat/julia-deps
     $ sudo add-apt-repository ppa:staticfloat/juliareleases
     $ sudo apt-get update
     $ sudo apt-get install julia


### PR DESCRIPTION
The [`julia-deps`](https://launchpad.net/~staticfloat/+archive/julia-deps) PPA is also required for the installation (tested on 12.04 LTS).
