### PR TITLE
Add a link to GSOC

### DIFF
--- a/_includes/links.html
+++ b/_includes/links.html
@@ -10,6 +10,7 @@
     | <a href="/community/">community</a>
     | <a href="/teaching/">teaching</a>
     | <a href="/publications/">publications</a>
+    | <a href="/gsoc/2014/">GSOC 2014</a>
     | <a href="http://feeds.feedburner.com/JuliaLang">rss</a>
   </p>
 </div>


### PR DESCRIPTION
It might be useful if the GSOC page is linkable from the homepage.
