### PR TITLE
encourage end-users to download the official release, not the prerelease 

### DIFF
--- a/downloads/index.md
+++ b/downloads/index.md
@@ -5,31 +5,6 @@ title:  Julia Downloads
 
 ### Download and install Julia on various Operating Systems
 
-# Prerelease
-
-## v0.3.0-prerelease
-
-<table class="downloads"><tbody>
-<tr>
-    <th> Windows Self-Extracting Archive (.exe) </th>
-    <td> <a href="http://s3.amazonaws.com/julialang/bin/winnt/x86/0.3/julia-0.3.0-prerelease-win32.exe">32-bit</a> </td>
-    <td> <a href="http://s3.amazonaws.com/julialang/bin/winnt/x64/0.3/julia-0.3.0-prerelease-win64.exe">64-bit</a> </td>
-</tr>
-<tr>
-    <th> Mac OS X Package (.dmg) </th>
-    <td> <a href="https://s3.amazonaws.com/julialang/bin/osx/x64/0.3/julia-0.3.0-prerelease-osx10.6.dmg">10.6 64-bit</a> </td>
-    <td> <a href="https://s3.amazonaws.com/julialang/bin/osx/x64/0.3/julia-0.3.0-prerelease-osx10.7+.dmg">10.7+ 64-bit</a> </td>
-</tr>
-<tr>
-    <th> Ubuntu packages </th>
-    <td colspan=2> <a href="https://launchpad.net/~staticfloat/+archive/julianightlies">32/64-bit</a> </td>
-</tr>
-<tr>
-    <th> Source </th>
-    <td colspan=2> <a href="https://github.com/JuliaLang/julia">GitHub</a> </td>
-</tr>
-</tbody></table>
-
 # Current Release
 
 ## v0.2.1
@@ -51,6 +26,38 @@ title:  Julia Downloads
 <tr>
     <th> Source </th>
     <td colspan=2> <a href="https://github.com/JuliaLang/julia/tree/v0.2.0">GitHub</a> </td>
+</tr>
+</tbody></table>
+
+# Prerelease snapshot
+
+This is a nightly snapshot of the latest version of Julia under
+development, which you can use to get a preview of the latest work on
+Julia.  However, because Julia is under heavy development, you may be
+unlucky and get a snapshot with a serious bug, or one which breaks
+existing packages.  Most users are advised to use the latest official
+release version of Julia, above.
+
+## v0.3.0-prerelease
+
+<table class="downloads"><tbody>
+<tr>
+    <th> Windows Self-Extracting Archive (.exe) </th>
+    <td> <a href="http://s3.amazonaws.com/julialang/bin/winnt/x86/0.3/julia-0.3.0-prerelease-win32.exe">32-bit</a> </td>
+    <td> <a href="http://s3.amazonaws.com/julialang/bin/winnt/x64/0.3/julia-0.3.0-prerelease-win64.exe">64-bit</a> </td>
+</tr>
+<tr>
+    <th> Mac OS X Package (.dmg) </th>
+    <td> <a href="https://s3.amazonaws.com/julialang/bin/osx/x64/0.3/julia-0.3.0-prerelease-osx10.6.dmg">10.6 64-bit</a> </td>
+    <td> <a href="https://s3.amazonaws.com/julialang/bin/osx/x64/0.3/julia-0.3.0-prerelease-osx10.7+.dmg">10.7+ 64-bit</a> </td>
+</tr>
+<tr>
+    <th> Ubuntu packages </th>
+    <td colspan=2> <a href="https://launchpad.net/~staticfloat/+archive/julianightlies">32/64-bit</a> </td>
+</tr>
+<tr>
+    <th> Source </th>
+    <td colspan=2> <a href="https://github.com/JuliaLang/julia">GitHub</a> </td>
 </tr>
 </tbody></table>
 


### PR DESCRIPTION
The current download page lists the 0.3 prerelease _first_, and then the 0.2 release.  I think this is a bad idea, because it means that most users end up downloading the prerelease, without realizing that they are getting an unstable snapshot.    This patch lists the current release first, then the prerelease, and warns the user that it is a nightly snapshot whose usability may change from day to day.

This has bitten me over and over again when working with students; it is a huge problem when whether something works depends on what _day_ the student downloaded it.   People just don't realize that not all prerelease snapshots are the same.

Encouraging users to download the prerelease was probably a good idea a year ago, when the prerelease was probably far less buggy than the release version, but I don't think the benefit is great enough now to foist unstable snapshots on unsuspecting users.
