### PR TITLE
Removed (dead) link to (nonexistent?) Meetup group

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -50,7 +50,6 @@ North America
 Europe
 
 * [London Julia Users Group](http://www.meetup.com/London-Julia-Users-Group/)
-* [sthlm.jl (Stockholm)](http://www.meetup.com/sthlm-jl/)
 
 Asia
 


### PR DESCRIPTION
The link is dead, no relevant group seems to exist on the Stockholm (at least there are [no search results](http://www.meetup.com/find/?allMeetups=true&keywords=julia&radius=100&userFreeform=stockholm&gcResults=Stockholm%2C+Sweden%3ASE%3Anull%3Anull%3AStockholm%3Anull%3Anull%3A59.32893000000001%3A18.064910000000054&sort=default) for "Julia" within 100 miles of Stockholm...) and [this post on the Julia Users mailing list](https://groups.google.com/forum/?fromgroups=#!topic/julia-users/V6aLwuqMPaI) doesn't seem to trigger any response =(
