### PR TITLE
add link to JuliaDiff

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -25,6 +25,7 @@ Various Julia projects are hosted under the following umbrella organizations on 
 * [JuliaQuant](https://github.com/JuliaQuant) – finance
 * [JuliaAstro](https://github.com/JuliaAstro) – astronomy
 * [JuliaGPU](https://github.com/JuliaGPU) - gpu computing
+* [JuliaDiff](http://www.juliadiff.org/) - differentiation tools
 
 # Twitter
 


### PR DESCRIPTION
Adds a link to JuliaDiff, which will soon be publicly announced. I broke the convention by adding a link juliadiff.org instead of the github page, which I think is more informative and useful. This should also probably be done for JuliaOpt, I'll do another PR for that if this change is not objectionable. The list of organizations could also use some alphabetic ordering.

@IainNZ
