### PR TITLE
RFC: Create generic julia install script

### DIFF
--- a/install-julia.sh
+++ b/install-julia.sh
@@ -39,9 +39,6 @@ case $(uname) in
       if [ -e /usr/local/bin/julia ]; then
         echo "/usr/local/bin/julia already exists, exiting"
         exit 1
-      elif ! [ "$JULIAVERSION" = "julianightlies" ]; then
-        echo "Only have generic Julia binaries for nightlies at this time, exiting"
-        exit 1
       fi
       case $(uname -m) in
         x86_64)


### PR DESCRIPTION
Closes https://github.com/JuliaLang/julia/issues/7364 - mostly intended for use on Travis and similar CI services, so you can do something like `curl http://julialang.org/install-julia.sh | sh -s $JULIAVERSION` and have it work for both Linux and Mac if you've enabled multi-OS support.

Generic Linux binary download links are apparently subject to change. I think the Windows side of this can be done properly if we set up Chocolatey (https://github.com/JuliaLang/julia/pull/7386).
