### PR TITLE
Fix JSON of benchmarks.ipynb, update to nbformat4

### DIFF
--- a/benchmarks.ipynb
+++ b/benchmarks.ipynb
@@ -1,81 +1,79 @@
 {
- "metadata": {
-  "language": "Julia",
-  "name": ""
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "using DataFrames\n",
-      "using Gadfly"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "benchmarks = readtable(\"benchmarks.csv\", names=[:language, :benchmark, :time])\n",
-      "cdata = benchmarks[benchmarks[:language].== \"c\", :]\n",
-      "benchmarks = join(benchmarks, cdata, on=:benchmark)\n",
-      "benchmarks[:time]./= benchmarks[:time_1]\n",
-      "benchmarks[:language] = PooledDataArray(benchmarks[:language])\n",
-      "#benchmarks[:language] = reorder(benchmarks[:language], benchmarks[:time])\n",
-      "benchmarks[:benchmark] = PooledDataArray(benchmarks[:benchmark])\n",
-      "#benchmarks[:benchmark] = reorder(benchmarks[:benchmark], benchmarks[:time])\n",
-      "benchmarks = benchmarks[benchmarks[:language].!= \"c\", :]\n",
-      "benchmarks[:language] = setlevels!(benchmarks[:language], Dict{UTF8String,Any}(benchmarks[:language],\n",
-      "  [ lang == \"javascript\" ? \"JavaScript\" : ucfirst(lang) for lang in benchmarks[:language]]));"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "p = plot(benchmarks,\n",
-      "    x = :language,\n",
-      "    y = :time,\n",
-      "    color = :benchmark,\n",
-      "    Scale.y_log10,\n",
-      "    Guide.ylabel(nothing),\n",
-      "    Guide.xlabel(nothing),\n",
-      "    Theme(\n",
-      "        default_point_size = 1mm,\n",
-      "        guide_title_position = :left,\n",
-      "        colorkey_swatch_shape = :circle,\n",
-      "        minor_label_font = \"Georgia\",\n",
-      "        major_label_font = \"Georgia\",\n",
-      "    ),\n",
-      ")\n",
-      "draw(SVG(8inch,8inch/golden), p)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "draw(SVG(\"_includes/benchmarks.svg\", 8inch, 8inch/golden), p)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    }
-   ],
-   "metadata": {}
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "using DataFrames\n",
+    "using Gadfly"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "benchmarks = readtable(\"benchmarks.csv\", names=[:language, :benchmark, :time])\n",
+    "cdata = benchmarks[benchmarks[:language].== \"c\", :]\n",
+    "benchmarks = join(benchmarks, cdata, on=:benchmark)\n",
+    "benchmarks[:time]./= benchmarks[:time_1]\n",
+    "benchmarks[:language] = PooledDataArray(benchmarks[:language])\n",
+    "#benchmarks[:language] = reorder(benchmarks[:language], benchmarks[:time])\n",
+    "benchmarks[:benchmark] = PooledDataArray(benchmarks[:benchmark])\n",
+    "#benchmarks[:benchmark] = reorder(benchmarks[:benchmark], benchmarks[:time])\n",
+    "benchmarks = benchmarks[benchmarks[:language].!= \"c\", :]\n",
+    "benchmarks[:language] = setlevels!(benchmarks[:language], Dict{UTF8String,Any}(benchmarks[:language],\n",
+    "  [ lang == \"javascript\" ? \"JavaScript\" : ucfirst(lang) for lang in benchmarks[:language]]));"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "p = plot(benchmarks,\n",
+    "    x = :language,\n",
+    "    y = :time,\n",
+    "    color = :benchmark,\n",
+    "    Scale.y_log10,\n",
+    "    Guide.ylabel(nothing),\n",
+    "    Guide.xlabel(nothing),\n",
+    "    Theme(\n",
+    "        default_point_size = 1mm,\n",
+    "        guide_title_position = :left,\n",
+    "        colorkey_swatch_shape = :circle,\n",
+    "        minor_label_font = \"Georgia\",\n",
+    "        major_label_font = \"Georgia\",\n",
+    "    ),\n",
+    ")\n",
+    "draw(SVG(8inch,8inch/golden), p)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "draw(SVG(\"_includes/benchmarks.svg\", 8inch, 8inch/golden), p)"
+   ]
   }
- ]
+ ],
+ "metadata": {
+  "language": "Julia"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }


### PR DESCRIPTION
When pointing out your benchmarks to someone, I noticed that the benchmarks notebook no longer rendered on the Notebook Viewer.

To address this I
- Deleted a trailing comma from the JSON (causing errors)
- Updated to nbformat4 using `find . -name '*.ipynb' -exec ipython nbconvert --to notebook {} --output {} \;` while on IPython master (not necessary, but good to do)
