### PR TITLE
Fix max-width and don't wrap links

### DIFF
--- a/_includes/links.html
+++ b/_includes/links.html
@@ -5,8 +5,7 @@
     <a href="/downloads/">downloads</a>&nbsp;|
     <a href="http://docs.julialang.org/">docs</a>&nbsp;|
     <a href="/blog/">blog</a>&nbsp;|
-    <a href="/community/">community</a>
-    <br/>
+    <a href="/community/">community</a>&nbsp;|
     <a href="/learning/">learning</a>&nbsp;|
     <a href="/teaching/">teaching</a>&nbsp;|
     <a href="/publications/">publications</a>&nbsp;|

--- a/css/screen.css
+++ b/css/screen.css
@@ -15,7 +15,7 @@ img {
 }
 
 #site {
-  max-width: 45em;
+  max-width: 785px;
   text-align: left;
   line-height: 1.5em;
   margin: 2.5em auto 2em;


### PR DESCRIPTION
Using `em` for the max-width results in it depending on the current font used (which I think is a bad thing). This increases the width back to the original level (I've used http://julialang.herokuapp.com as a reference) and reverts https://github.com/JuliaLang/julialang.github.com/commit/dd55a10133c77e6fb8e117f60783dba774b62a30.

Also fixes the download page, see https://github.com/JuliaLang/julialang.github.com/issues/63#issuecomment-66119938.
