### PR TITLE
Use Liberation Serif instead of DejaVu Serif as a fallback for Georgia

### DIFF
--- a/css/screen.css
+++ b/css/screen.css
@@ -7,7 +7,7 @@
 
 body {
   background-color: white;
-  font-family: Georgia, 'DejaVu Serif', serif;
+  font-family: Georgia, 'Liberation Serif', serif;
 }
 
 img {


### PR DESCRIPTION
DejaVu Serif has different metrics (wider) than Georgia. This results in a line break in the menu on Linux for me. I think `Liberation Serif` is a better fallback.

(Also note that serif defaults to `DejaVu Serif` on most Linux systems so there's no change at all for users who haver neither Georgia nor Liberation Serif)
