### PR TITLE
Add mention of juliabloggers.com on the Blog page

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -4,6 +4,7 @@ title:  The Julia Blog
 ---
 <div id="blogindex">
   <p>The Julia blog discusses issues of numerical, technical, distributed and parallel computing, as well as programming language design, and how these issues touch upon the design and implementation of the Julia programming language.</p>
+  <p>Blogs from the broader Julia community can be found at [Julia bloggers](http://www.juliabloggers.com).</p>
 
   <ul class="posts">
     {% for post in site.categories.blog %}


### PR DESCRIPTION
This is to avoid the feeling that nothing happens in the Julia community, since posts on the official blogs are relatively unfrequent. People won't always think of going to the "community" page to get more blogs.

Unfortunately I couldn't test it, `gem install jekyll` doesn't work here (I'll investigate this).
