### PR TITLE
Add packages link, remove rss link

### DIFF
--- a/_includes/links.html
+++ b/_includes/links.html
@@ -4,12 +4,12 @@
     <a href="https://github.com/JuliaLang/julia">source</a>&nbsp;|
     <a href="/downloads/">downloads</a>&nbsp;|
     <a href="http://docs.julialang.org/">docs</a>&nbsp;|
+    <a href="http://pkg.julialang.org/">packages</a>&nbsp;|
     <a href="/blog/">blog</a>&nbsp;|
     <a href="/community/">community</a>&nbsp;|
     <a href="/learning/">learning</a>&nbsp;|
     <a href="/teaching/">teaching</a>&nbsp;|
     <a href="/publications/">publications</a>&nbsp;|
-    <a href="http://juliacon.org">juliacon</a>&nbsp;|
-    <a href="http://feeds.feedburner.com/JuliaLang">rss</a>
+    <a href="http://juliacon.org">juliacon</a>
   </p>
 </div>


### PR DESCRIPTION
Closes #112.

@simonbyrne's suggestion of removing the rss link provides just enough space so that "packages" can be squeezed in.

'Learning', 'teaching' and 'publications' could probably be consolidated in a future change.

![screen shot 2015-01-03 at 12 37 21 am](https://cloud.githubusercontent.com/assets/1732/5601703/e963ee74-92e0-11e4-917a-b74afa3920c3.png)
