### PR TITLE
Create mixin for videos from JuliaCon (closes #257)

### DIFF
--- a/_includes/juliacon-player.md
+++ b/_includes/juliacon-player.md
@@ -1,0 +1,3 @@
+<div style="text-align: center">
+    <iframe id="juliacon-player" align="center" width="560" height="315" frameborder="0" allowfullscreen></iframe>
+</div>

--- a/_layouts/common.html
+++ b/_layouts/common.html
@@ -24,5 +24,17 @@
 Julia is a <a href="http://numfocus.org/projects/index.html">NumFocus project</a>.
 </div>
 </div>
+
+<script type="text/javascript">
+    var playlistId = 'PLP8iPy9hna6Sdx4soiGrSefrmOPdUWixM',
+        videoCount = 61,
+        index = Math.floor(Math.random() * videoCount),
+        playlistUrl = 'https://www.youtube.com/embed/videoseries?list=' + playlistId + '&index=' + index,
+        videoFrame = document.getElementById('juliacon-player');
+
+    if (videoFrame) {
+        videoFrame.src = playlistUrl;
+    }
+</script>
 </body>
 </html>

--- a/index.md
+++ b/index.md
@@ -11,6 +11,8 @@ In addition, the Julia developer community is contributing a number of [external
 Julia programs are organized around [multiple dispatch](http://docs.julialang.org/en/release-0.3/manual/methods/#man-methods); by defining functions and overloading them for different combinations of argument types, which can also be user-defined.
 For a more in-depth discussion of the rationale and advantages of Julia over other systems, see the following highlights or read the [introduction](http://docs.julialang.org/en/release-0.3/manual/introduction/) in the [online manual](http://docs.julialang.org).
 
+{% include juliacon-player.md %}
+
 # A Summary of Features
 
 * [Multiple dispatch](http://en.wikipedia.org/wiki/Multiple_dispatch): providing ability to define function behavior across many combinations of argument types

--- a/index.md
+++ b/index.md
@@ -11,8 +11,6 @@ In addition, the Julia developer community is contributing a number of [external
 Julia programs are organized around [multiple dispatch](http://docs.julialang.org/en/release-0.3/manual/methods/#man-methods); by defining functions and overloading them for different combinations of argument types, which can also be user-defined.
 For a more in-depth discussion of the rationale and advantages of Julia over other systems, see the following highlights or read the [introduction](http://docs.julialang.org/en/release-0.3/manual/introduction/) in the [online manual](http://docs.julialang.org).
 
-{% include juliacon-player.md %}
-
 # A Summary of Features
 
 * [Multiple dispatch](http://en.wikipedia.org/wiki/Multiple_dispatch): providing ability to define function behavior across many combinations of argument types


### PR DESCRIPTION
This creates a mixin that can be used to include a random video from the JuliaCon 2015 playlist on Youtube. It's usage is exemplified by the changes to `index.md`.