### PR TITLE
Fix br tags in juliacon 2014 blog posts

### DIFF
--- a/blog/_posts/2014-08-09-juliacon-opening-session.md
+++ b/blog/_posts/2014-08-09-juliacon-opening-session.md
@@ -16,9 +16,11 @@ Tim Holy is a Professor in the Department of Anatomy and Neurobiology at Washing
 - **GitHub:** <https://github.com/timholy>
 
 <br/>
-<iframe width="560" height="315" src="//www.youtube.com/embed/FA-1B_amwt8?list=PLP8iPy9hna6TSRouJfvobfxkZFYiPSvPd" frameborder="0" allowfullscreen></iframe>
+
+<div style="text-align: center"><iframe width="560" height="315" src="//www.youtube.com/embed/FA-1B_amwt8?list=PLP8iPy9hna6TSRouJfvobfxkZFYiPSvPd" frameborder="0" allowfullscreen></iframe></div>
 
 <br/>
+
 ### Pontus Stenetorp — Natural Language Processing with Julia
 
 Pontus Stenetorp is a Japan Society for the Promotion of Science Postdoctoral Research Fellow at the University of Tokyo working in the areas of machine learning and natural language processing (NLP). In this talk, Pontus describes his recent experience in learning Julia and how Julia and its community have helped in his implementing a transition-based dependency parser in Julia.
@@ -28,9 +30,11 @@ Pontus Stenetorp is a Japan Society for the Promotion of Science Postdoctoral Re
 - **GitHub:** <https://github.com/ninjin>
 
 <br/>
-<iframe width="560" height="315" src="//www.youtube.com/embed/OrFxjE44COc?list=PLP8iPy9hna6TSRouJfvobfxkZFYiPSvPd" frameborder="0" allowfullscreen></iframe>
+
+<div style="text-align: center"><iframe width="560" height="315" src="//www.youtube.com/embed/OrFxjE44COc?list=PLP8iPy9hna6TSRouJfvobfxkZFYiPSvPd" frameborder="0" allowfullscreen></iframe></div>
 
 <br/>
+
 ### Speed vs. Correctness (led by Arch Robison)
 
 Arch Robison is a Senior Principal Engineer at Intel and is an expert in parallel programming, being the original designer of the widely used Intel Threading Building Blocks library. In this session, Arch discusses the tradeoffs between instruction-level correctness and its implications for compiler optimizations.
@@ -39,4 +43,5 @@ Arch Robison is a Senior Principal Engineer at Intel and is an expert in paralle
 - **GitHub:** <https://github.com/ArchRobison>
 
 <br/>
-<iframe width="560" height="315" src="//www.youtube.com/embed/GFTCQNYddhs?list=PLP8iPy9hna6TSRouJfvobfxkZFYiPSvPd" frameborder="0" allowfullscreen></iframe>
+
+<div style="text-align: center"><iframe width="560" height="315" src="//www.youtube.com/embed/GFTCQNYddhs?list=PLP8iPy9hna6TSRouJfvobfxkZFYiPSvPd" frameborder="0" allowfullscreen></iframe></div>

--- a/blog/_posts/2014-08-09-juliacon-opt-session.md
+++ b/blog/_posts/2014-08-09-juliacon-opt-session.md
@@ -16,9 +16,11 @@ Iain Dunning and Joey Huchette are both doctoral students in the Massachusetts I
 - **GitHub:** <https://github.com/IainNZ> <https://github.com/joehuchette> <https://github.com/mlubin>
 
 <br/>
-<iframe width="560" height="315" src="//www.youtube.com/embed/VwZvUvXX-vY?list=PLP8iPy9hna6TSRouJfvobfxkZFYiPSvPd" frameborder="0" allowfullscreen></iframe>
+
+<div style="text-align: center"><iframe width="560" height="315" src="//www.youtube.com/embed/VwZvUvXX-vY?list=PLP8iPy9hna6TSRouJfvobfxkZFYiPSvPd" frameborder="0" allowfullscreen></iframe></div>
 
 <br/>
+
 ### Madeleine Udell — Convex Optimization in Julia
 
 Madeleine Udell is a PhD candidate in Computational & Mathematical Engineering at Stanford University, where she works with Professor Stephen Boyd. Madeleine's work focuses on modeling and solving large-scale optimization problems and in finding and exploiting structure in high dimensional data. She is the lead developer of the CVX.jl package.
@@ -28,6 +30,7 @@ Madeleine Udell is a PhD candidate in Computational & Mathematical Engineering a
 - **Website:** <http://web.stanford.edu/~udell/>
 
 <br/>
-<iframe width="560" height="315" src="//www.youtube.com/embed/SoI0lEaUvTs?list=PLP8iPy9hna6TSRouJfvobfxkZFYiPSvPd" frameborder="0" allowfullscreen></iframe>
+
+<div style="text-align: center"><iframe width="560" height="315" src="//www.youtube.com/embed/SoI0lEaUvTs?list=PLP8iPy9hna6TSRouJfvobfxkZFYiPSvPd" frameborder="0" allowfullscreen></iframe></div>
 
 <br/>


### PR DESCRIPTION
Fixes rendering issues due to `<br\>` in http://julialang.org/blog/2014/08/juliacon-opt-session/ and http://julialang.org/blog/2014/08/juliacon-opening-session/. Also centers the videos.