### PR TITLE
Don't claim benchmarks are idiomatic

### DIFF
--- a/index.md
+++ b/index.md
@@ -69,7 +69,7 @@ with <a href="https://github.com/dcjones/Gadfly.jl">Gadfly</a>.
 
 These benchmarks, while not comprehensive, do test compiler performance on a range of common code patterns, such as function calls, string parsing, sorting, numerical loops, random number generation, and array operations.
 It is important to note that these benchmark implementations are not written for absolute maximal performance (the fastest code to compute `fib(20)` is the constant literal `6765`).
-Rather, all of the benchmarks are written to test the performance of specific algorithms, expressed in a reasonable idiom in each language.
+Rather, all of the benchmarks are written to test the performance of specific algorithms implemented in each language.
 In particular, all languages use the same algorithm: the Fibonacci benchmarks are all recursive while the pi summation benchmarks are all iterative; the "algorithm" for random matrix multiplication is to call LAPACK, except where that's not possible, such as in JavaScript.
 The point of these benchmarks is to compare the performance of specific *algorithms* across language implementations, not to compare the fastest means of computing a result, which in most high-level languages relies on calling C code.
 Raw benchmark numbers in CSV format are available [here](/benchmarks.csv).


### PR DESCRIPTION
The assertion that we use a "reasonable idiom in each language" is too easily argued against. I believe that phrase doesn't help sell the benchmarks. If you believe that, I think this change helps to provide one less avenue for attack.