### PR TITLE
Mention that most development discussions happen on GitHub

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -12,7 +12,7 @@ them in all Julia related forums.
 
 * [julia-news](https://groups.google.com/group/julia-news) – low traffic mailing list for important announcements, such as new releases.
 * [julia-users][julia-users] – discussion around the usage of Julia. New users of Julia can ask their questions here. As a courtesy to others, do check the archives and documentation to see if a particular question is already answered.
-* [julia-dev](https://groups.google.com/group/julia-dev) – discussions related to the development of Julia itself.
+* [julia-dev](https://groups.google.com/group/julia-dev) – discussions related to the development of Julia itself. Note that this is not the primary forum for the development of Julia: most of the discussions take place on GitHub instead (see below).
 * [julia-stats](https://groups.google.com/group/julia-stats) – special purpose mailing list for discussions related to statistical programming with Julia. Topics of interest include DataFrame support, GLM modeling, and automatic generation of MCMC code for Bayesian models.
 * [julia-opt](https://groups.google.com/group/julia-opt) – discussions related to numerical optimization in julia. This includes Mathematical Programming (linear, mixed-integer, conic, semi-definite, etc.), constrained and unconstrained gradient-based and gradient-free optimization, and related topics.
 * [JuliaBox](https://groups.google.com/group/julia-box) – discussions related to running Julia in the so-called cloud.


### PR DESCRIPTION
This can prevent newcomers who want to follow the development
from wondering why the julia-dev traffic is so low. People
have mentioned in the past that they didn't discover immediately
that they had to subscribe to GitHub notifications.