### PR TITLE
update link of JuliaCN

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -115,7 +115,7 @@ Asia
 
 * [Bangalore Julia User Group](http://www.meetup.com/Bangalore-Julia-User-Group/)
 * [Julia Tokyo](http://julia.tokyo/)
-* [Julia China](http://julia.org.cn/)
+* [Julia China](http://julialang.cn/)
 
 Australia
 


### PR DESCRIPTION
We finished the homepage of Chinese community, and the julia.org.cn is for disccusions, which is included in the [homepage](http://julialang.cn)  :-)

The homepage is in the [repo](https://github.com/JuliaCN/juliacn.github.io)