### PR TITLE
community: add link to Berlin group

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -111,6 +111,7 @@ Europe
 * [London Julia Users Group](http://www.meetup.com/London-Julia-Users-Group/)
 * [Zurich Julia Users Group](http://www.meetup.com/Zurich-Julia-User-Group/)
 * [Vienna Julia Meetup](http://www.meetup.com/Vienna-Julia-Meetup/)
+* [Julia Users Berlin](http://julia-users-berlin.github.io/)
 
 Asia
 


### PR DESCRIPTION
We're just establishing a regular user group in Berlin.
CC @daveh19