### PR TITLE
Change Plot recommendations

### DIFF
--- a/downloads/index.md
+++ b/downloads/index.md
@@ -13,10 +13,7 @@ We provide several ways for you to run Julia:
 
 Plotting capabilities are provided by external packages such as
 [PyPlot.jl](https://github.com/stevengj/PyPlot.jl) and
-[Gadfly.jl](http://gadflyjl.org). You can also do much more with
-[Compose.jl](http://composejl.org), a vector graphics library for
-Julia. Look at the [plotting instructions](plotting.html) to install a
-plotting package. If you are using JuliaBox, all these plotting
+[Gadfly.jl](http://gadflyjl.org). A package which integrates most of Julia's plotting backends into one convenient and well-documented API is [Plots.jl](https://github.com/tbreloff/Plots.jl). If you are using JuliaBox, all these plotting
 packages are pre-installed.
 
 ## Julia (command line version)

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -14,8 +14,7 @@ We provide several ways for you to run Julia:
 Plotting capabilities are provided by external packages such as
 [PyPlot.jl](https://github.com/stevengj/PyPlot.jl) and
 [Gadfly.jl](http://gadflyjl.org). A package which integrates most of Julia's plotting backends into one convenient and well-documented API is [Plots.jl](https://github.com/tbreloff/Plots.jl). Look at the [plotting instructions](plotting.html) to install a
-plotting package. If you are using JuliaBox, all these plotting
-packages are pre-installed.
+plotting package. If you are using JuliaBox, all of these plotting packages are pre-installed.
 
 ## Julia (command line version)
 <table class="downloads"><tbody>

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -12,9 +12,11 @@ We provide several ways for you to run Julia:
 * In the browser on [JuliaBox.com](https://www.juliabox.com) with Jupyter notebooks. No installation is required -- just point your browser there, login and start computing.
 
 Plotting capabilities are provided by external packages such as
-[PyPlot.jl](https://github.com/stevengj/PyPlot.jl) and
-[Gadfly.jl](http://gadflyjl.org). A package which integrates most of Julia's plotting backends into one convenient and well-documented API is [Plots.jl](https://github.com/tbreloff/Plots.jl). Look at the [plotting instructions](plotting.html) to install a
-plotting package. If you are using JuliaBox, all of these plotting packages are pre-installed.
+[PyPlot.jl](https://github.com/stevengj/PyPlot.jl) and [Gadfly.jl](http://gadflyjl.org). 
+A package which integrates most of Julia's plotting backends into one convenient and 
+well-documented API is [Plots.jl](https://github.com/tbreloff/Plots.jl). Look at the 
+[plotting instructions](plotting.html) to install a plotting package. If you are using 
+JuliaBox, all of these plotting packages are pre-installed.
 
 ## Julia (command line version)
 <table class="downloads"><tbody>

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -13,7 +13,8 @@ We provide several ways for you to run Julia:
 
 Plotting capabilities are provided by external packages such as
 [PyPlot.jl](https://github.com/stevengj/PyPlot.jl) and
-[Gadfly.jl](http://gadflyjl.org). A package which integrates most of Julia's plotting backends into one convenient and well-documented API is [Plots.jl](https://github.com/tbreloff/Plots.jl). If you are using JuliaBox, all these plotting
+[Gadfly.jl](http://gadflyjl.org). A package which integrates most of Julia's plotting backends into one convenient and well-documented API is [Plots.jl](https://github.com/tbreloff/Plots.jl). Look at the [plotting instructions](plotting.html) to install a
+plotting package. If you are using JuliaBox, all these plotting
 packages are pre-installed.
 
 ## Julia (command line version)


### PR DESCRIPTION
Plots.jl is in the top 20 packages [according to the Julia Pulse (ranking via stars)](http://pkg.julialang.org/pulse.html). Because of its user-friendliness and high amount of development activity (with help always available in the Gitter channel), I believe it should be right here, front and center, on the Julia webiste. On the otherhand, most people will not be plotting directly into Compose.jl, and so I believe showing that as a "plotting package" confuses most newcommers (as evidenced by the questions we get in the Gitter/IRC about it. Plus the link was broken).

So I added a part for Plots.jl and removed the Part about Compose.jl. I think Plots.jl should come by default on JuliaBox to match this as well.