### PR TITLE
Link to the 0.5 release candidate downloads

### DIFF
--- a/downloads/index.md
+++ b/downloads/index.md
@@ -67,6 +67,43 @@ Older releases of Julia for all platforms are available on the [Older releases p
 
 For Julia 0.3, only critical bugfixes are being supported. Releases older than 0.3 are now unmaintained.
 
+# Release Candidates (v0.5.0-rc1)
+
+We are currently testing release candidates for the next version of Julia. Please see
+[platform](platform.html) specific instructions if you have trouble installing Julia.
+Checksums for this release are available in both
+[MD5](https://s3.amazonaws.com/julialang/bin/checksums/julia-0.5.0-rc1.md5)
+and [SHA256](https://s3.amazonaws.com/julialang/bin/checksums/julia-0.5.0-rc1.sha256) format.
+Download the release candidate here, and please report any issues to the
+[issue tracker](https://github.com/JuliaLang/julia/issues) on GitHub.
+Full tarballs contain all dependencies bundled within the tarball alongside Julia,
+allowing for easy install in environments without network access. The standard
+tarball is much smaller in size, but will download dependency tarballs on demand.
+
+## Julia (command line version)
+<table class="downloads"><tbody>
+<tr>
+    <th> Windows Self-Extracting Archive (.exe) </th>
+    <td colspan="3"> <a href="https://s3.amazonaws.com/julialang/bin/winnt/x86/0.5/julia-0.5.0-rc1-win32.exe">32-bit</a> </td>
+    <td colspan="3"> <a href="https://s3.amazonaws.com/julialang/bin/winnt/x64/0.5/julia-0.5.0-rc1-win64.exe">64-bit</a> </td>
+</tr>
+<tr>
+    <th> Mac OS X Package (.dmg) </th>
+    <td colspan="6"> <a href="https://s3.amazonaws.com/julialang/bin/osx/x64/0.5/julia-0.5.0-rc1-osx10.7+.dmg">10.7+ 64-bit</a> </td>
+</tr>
+<tr>
+    <th> Generic Linux binaries </th>
+    <td colspan="3"> <a href="https://julialang.s3.amazonaws.com/bin/linux/x86/0.5/julia-0.5.0-rc1-linux-i686.tar.gz">32-bit</a> (<a href="https://julialang.s3.amazonaws.com/bin/linux/x86/0.5/julia-0.5.0-rc1-linux-i686.tar.gz.asc">GPG</a>)</td>
+    <td colspan="3"> <a href="https://julialang.s3.amazonaws.com/bin/linux/x64/0.5/julia-0.5.0-rc1-linux-x86_64.tar.gz">64-bit</a> (<a href="https://julialang.s3.amazonaws.com/bin/linux/x64/0.5/julia-0.5.0-rc1-linux-x86_64.tar.gz.asc">GPG</a>)</td>
+</tr>
+<tr>
+    <th> Source </th>
+    <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v0.5.0-rc1/julia-0.5.0-rc1.tar.gz">Tarball</a> (<a href="https://github.com/JuliaLang/julia/releases/download/v0.5.0-rc1/julia-0.5.0-rc1.tar.gz.asc">GPG</a>) </td>
+    <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v0.5.0-rc1/julia-0.5.0-rc1-full.tar.gz">Tarball with dependencies</a> (<a href="https://github.com/JuliaLang/julia/releases/download/v0.5.0-rc1/julia-0.5.0-rc1-full.tar.gz.asc">GPG</a>) </td>
+    <td colspan="2"> <a href="https://github.com/JuliaLang/julia/tree/release-0.5">GitHub</a> </td>
+</tr>
+</tbody></table>
+
 # Nightly builds
 
 These are bleeding-edge binaries of the latest version of Julia under
@@ -105,7 +142,7 @@ are advised to use the latest official release version of Julia, above.
 
 # Download verification
 All Julia binary releases are cryptographically secured using the traditional methods on each
-operating system platform.  OSX and Windows releases are codesigned by certificates that are
+operating system platform.  OS X and Windows releases are codesigned by certificates that are
 verified by the operating system before installation.  Generic Linux tarballs and source tarballs
 are signed via GPG using [this key](../juliareleases.asc).  Ubuntu and Fedora/RHEL/CentOS/SL
 releases are signed by their own keys that are verified by the package managers when installing.

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -84,22 +84,22 @@ tarball is much smaller in size, but will download dependency tarballs on demand
 <table class="downloads"><tbody>
 <tr>
     <th> Windows Self-Extracting Archive (.exe) </th>
-    <td colspan="3"> <a href="https://s3.amazonaws.com/julialang/bin/winnt/x86/0.5/julia-0.5.0-rc1-win32.exe">32-bit</a> </td>
-    <td colspan="3"> <a href="https://s3.amazonaws.com/julialang/bin/winnt/x64/0.5/julia-0.5.0-rc1-win64.exe">64-bit</a> </td>
+    <td colspan="3"> <a href="https://s3.amazonaws.com/julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe">32-bit</a> </td>
+    <td colspan="3"> <a href="https://s3.amazonaws.com/julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe">64-bit</a> </td>
 </tr>
 <tr>
     <th> Mac OS X Package (.dmg) </th>
-    <td colspan="6"> <a href="https://s3.amazonaws.com/julialang/bin/osx/x64/0.5/julia-0.5.0-rc1-osx10.7+.dmg">10.7+ 64-bit</a> </td>
+    <td colspan="6"> <a href="https://s3.amazonaws.com/julialang/bin/osx/x64/0.5/julia-0.5-latest-osx10.7+.dmg">10.7+ 64-bit</a> </td>
 </tr>
 <tr>
     <th> Generic Linux binaries </th>
-    <td colspan="3"> <a href="https://julialang.s3.amazonaws.com/bin/linux/x86/0.5/julia-0.5.0-rc1-linux-i686.tar.gz">32-bit</a> (<a href="https://julialang.s3.amazonaws.com/bin/linux/x86/0.5/julia-0.5.0-rc1-linux-i686.tar.gz.asc">GPG</a>)</td>
-    <td colspan="3"> <a href="https://julialang.s3.amazonaws.com/bin/linux/x64/0.5/julia-0.5.0-rc1-linux-x86_64.tar.gz">64-bit</a> (<a href="https://julialang.s3.amazonaws.com/bin/linux/x64/0.5/julia-0.5.0-rc1-linux-x86_64.tar.gz.asc">GPG</a>)</td>
+    <td colspan="3"> <a href="https://julialang.s3.amazonaws.com/bin/linux/x86/0.5/julia-0.5-latest-linux-i686.tar.gz">32-bit</a> (<a href="https://julialang.s3.amazonaws.com/bin/linux/x86/0.5/julia-0.5-latest-linux-i686.tar.gz.asc">GPG</a>)</td>
+    <td colspan="3"> <a href="https://julialang.s3.amazonaws.com/bin/linux/x64/0.5/julia-0.5-latest-linux-x86_64.tar.gz">64-bit</a> (<a href="https://julialang.s3.amazonaws.com/bin/linux/x64/0.5/julia-0.5-latest-linux-x86_64.tar.gz.asc">GPG</a>)</td>
 </tr>
 <tr>
     <th> Source </th>
-    <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v0.5.0-rc1/julia-0.5.0-rc1.tar.gz">Tarball</a> (<a href="https://github.com/JuliaLang/julia/releases/download/v0.5.0-rc1/julia-0.5.0-rc1.tar.gz.asc">GPG</a>) </td>
-    <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v0.5.0-rc1/julia-0.5.0-rc1-full.tar.gz">Tarball with dependencies</a> (<a href="https://github.com/JuliaLang/julia/releases/download/v0.5.0-rc1/julia-0.5.0-rc1-full.tar.gz.asc">GPG</a>) </td>
+    <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v0.5.0-rc1/julia-0.5.0-rc1-latest.tar.gz">Tarball</a> (<a href="https://github.com/JuliaLang/julia/releases/download/v0.5.0-rc1/julia-0.5.0-rc1-latest.tar.gz.asc">GPG</a>) </td>
+    <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v0.5-latest/julia-0.5-latest-full.tar.gz">Tarball with dependencies</a> (<a href="https://github.com/JuliaLang/julia/releases/download/v0.5.0-rc1/julia-0.5.0-rc1-full.tar.gz.asc">GPG</a>) </td>
     <td colspan="2"> <a href="https://github.com/JuliaLang/julia/tree/release-0.5">GitHub</a> </td>
 </tr>
 </tbody></table>

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -93,7 +93,7 @@ tarball is much smaller in size, but will download dependency tarballs on demand
 </tr>
 <tr>
     <th> Generic Linux binaries </th>
-    <td colspan="3"> <a href="https://julialang.s3.amazonaws.com/bin/linux/x86/0.5/julia-0.5-latest-linux-i686.tar.gz">32-bit</a> (<a href="https://julialang.s3.amazonaws.com/bin/linux/x86/0.5/julia-0.5-latest-linux-i686.tar.gz.asc">GPG</a>)</td>
+    <td colspan="3"> <a href="https://julialang.s3.amazonaws.com/bin/linux/x86/0.5/julia-0.5-latest-linux-i686.tar.gz">32-bit</a> (<a href="https://julialang.s3.amazonaws.com/bin/linux/x86/0.5/julia-0.5.0-rc2-linux-i686.tar.gz.asc">GPG</a>)</td>
     <td colspan="3"> <a href="https://julialang.s3.amazonaws.com/bin/linux/x64/0.5/julia-0.5.0-rc2-linux-x86_64.tar.gz">64-bit</a> (<a href="https://julialang.s3.amazonaws.com/bin/linux/x64/0.5/julia-0.5.0-rc2-linux-x86_64.tar.gz.asc">GPG</a>)</td>
 </tr>
 <tr>

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -94,11 +94,11 @@ tarball is much smaller in size, but will download dependency tarballs on demand
 <tr>
     <th> Generic Linux binaries </th>
     <td colspan="3"> <a href="https://julialang.s3.amazonaws.com/bin/linux/x86/0.5/julia-0.5-latest-linux-i686.tar.gz">32-bit</a> (<a href="https://julialang.s3.amazonaws.com/bin/linux/x86/0.5/julia-0.5-latest-linux-i686.tar.gz.asc">GPG</a>)</td>
-    <td colspan="3"> <a href="https://julialang.s3.amazonaws.com/bin/linux/x64/0.5/julia-0.5-latest-linux-x86_64.tar.gz">64-bit</a> (<a href="https://julialang.s3.amazonaws.com/bin/linux/x64/0.5/julia-0.5-latest-linux-x86_64.tar.gz.asc">GPG</a>)</td>
+    <td colspan="3"> <a href="https://julialang.s3.amazonaws.com/bin/linux/x64/0.5/julia-0.5.0-rc2-linux-x86_64.tar.gz">64-bit</a> (<a href="https://julialang.s3.amazonaws.com/bin/linux/x64/0.5/julia-0.5.0-rc2-linux-x86_64.tar.gz.asc">GPG</a>)</td>
 </tr>
 <tr>
     <th> Source </th>
-    <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v0.5.0-rc2/julia-0.5.0-rc2-latest.tar.gz">Tarball</a> (<a href="https://github.com/JuliaLang/julia/releases/download/v0.5.0-rc2/julia-0.5.0-rc2-latest.tar.gz.asc">GPG</a>) </td>
+    <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v0.5.0-rc2/julia-0.5.0-rc2.tar.gz">Tarball</a> (<a href="https://github.com/JuliaLang/julia/releases/download/v0.5.0-rc2/julia-0.5.0-rc2.tar.gz.asc">GPG</a>) </td>
     <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v0.5.0-rc2/julia-0.5.0-rc2-full.tar.gz">Tarball with dependencies</a> (<a href="https://github.com/JuliaLang/julia/releases/download/v0.5.0-rc2/julia-0.5.0-rc2-full.tar.gz.asc">GPG</a>) </td>
     <td colspan="2"> <a href="https://github.com/JuliaLang/julia/tree/release-0.5">GitHub</a> </td>
 </tr>

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -67,13 +67,13 @@ Older releases of Julia for all platforms are available on the [Older releases p
 
 For Julia 0.3, only critical bugfixes are being supported. Releases older than 0.3 are now unmaintained.
 
-# Release Candidates (v0.5.0-rc1)
+# Release Candidates (v0.5.0-rc2)
 
 We are currently testing release candidates for the next version of Julia. Please see
 [platform](platform.html) specific instructions if you have trouble installing Julia.
 Checksums for this release are available in both
-[MD5](https://s3.amazonaws.com/julialang/bin/checksums/julia-0.5.0-rc1.md5)
-and [SHA256](https://s3.amazonaws.com/julialang/bin/checksums/julia-0.5.0-rc1.sha256) format.
+[MD5](https://s3.amazonaws.com/julialang/bin/checksums/julia-0.5.0-rc2.md5)
+and [SHA256](https://s3.amazonaws.com/julialang/bin/checksums/julia-0.5.0-rc2.sha256) format.
 Download the release candidate here, and please report any issues to the
 [issue tracker](https://github.com/JuliaLang/julia/issues) on GitHub.
 Full tarballs contain all dependencies bundled within the tarball alongside Julia,
@@ -98,8 +98,8 @@ tarball is much smaller in size, but will download dependency tarballs on demand
 </tr>
 <tr>
     <th> Source </th>
-    <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v0.5.0-rc1/julia-0.5.0-rc1-latest.tar.gz">Tarball</a> (<a href="https://github.com/JuliaLang/julia/releases/download/v0.5.0-rc1/julia-0.5.0-rc1-latest.tar.gz.asc">GPG</a>) </td>
-    <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v0.5.0-rc1/julia-0.5.0-rc1-full.tar.gz">Tarball with dependencies</a> (<a href="https://github.com/JuliaLang/julia/releases/download/v0.5.0-rc1/julia-0.5.0-rc1-full.tar.gz.asc">GPG</a>) </td>
+    <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v0.5.0-rc2/julia-0.5.0-rc2-latest.tar.gz">Tarball</a> (<a href="https://github.com/JuliaLang/julia/releases/download/v0.5.0-rc2/julia-0.5.0-rc2-latest.tar.gz.asc">GPG</a>) </td>
+    <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v0.5.0-rc2/julia-0.5.0-rc2-full.tar.gz">Tarball with dependencies</a> (<a href="https://github.com/JuliaLang/julia/releases/download/v0.5.0-rc2/julia-0.5.0-rc2-full.tar.gz.asc">GPG</a>) </td>
     <td colspan="2"> <a href="https://github.com/JuliaLang/julia/tree/release-0.5">GitHub</a> </td>
 </tr>
 </tbody></table>

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -99,7 +99,7 @@ tarball is much smaller in size, but will download dependency tarballs on demand
 <tr>
     <th> Source </th>
     <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v0.5.0-rc1/julia-0.5.0-rc1-latest.tar.gz">Tarball</a> (<a href="https://github.com/JuliaLang/julia/releases/download/v0.5.0-rc1/julia-0.5.0-rc1-latest.tar.gz.asc">GPG</a>) </td>
-    <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v0.5-latest/julia-0.5-latest-full.tar.gz">Tarball with dependencies</a> (<a href="https://github.com/JuliaLang/julia/releases/download/v0.5.0-rc1/julia-0.5.0-rc1-full.tar.gz.asc">GPG</a>) </td>
+    <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v0.5.0-rc1/julia-0.5.0-rc1-full.tar.gz">Tarball with dependencies</a> (<a href="https://github.com/JuliaLang/julia/releases/download/v0.5.0-rc1/julia-0.5.0-rc1-full.tar.gz.asc">GPG</a>) </td>
     <td colspan="2"> <a href="https://github.com/JuliaLang/julia/tree/release-0.5">GitHub</a> </td>
 </tr>
 </tbody></table>


### PR DESCRIPTION
I used the 0.4-rc version of this file as a template and I took the download links from https://groups.google.com/forum/#!topic/julia-users/shrnNHpyliA.

Fixes https://github.com/JuliaLang/julia/issues/17881