### PR TITLE
Add Power nightlies link

### DIFF
--- a/downloads/index.md
+++ b/downloads/index.md
@@ -126,7 +126,11 @@ are advised to use the latest official release version of Julia, above.
     <th> Generic Linux binaries </th>
     <td> <a href="https://status.julialang.org/download/linux-i686">32-bit (X86)</a> </td>
     <td> <a href="https://status.julialang.org/download/linux-x86_64">64-bit (X86)</a> </td>
-    <td> <a href="https://status.julialang.org/download/linux-arm">32-bit (ARM)</a> </td>
+</tr>
+<tr>
+    <th> Linux builds for other architectures </th>
+    <td> <a href="https://status.julialang.org/download/linux-arm">ARM 32-bit hard float</a> </td>
+    <td> <a href="https://status.julialang.org/download/linux-powerpc64le">PowerPC 64 little endian</a> </td>
 </tr>
 <tr>
     <th> Fedora/RHEL/CentOS/SL packages (.rpm) </th>


### PR DESCRIPTION
Separate arm and power on a different table row from x86, since they aren't really "generic linux binaries" in the same sense as we build for x86. They won't work on any distribution other than the one the buildbot happens to be using.

cc @viralbshah