### PR TITLE
Replace references to Mac OS X with macOS

### DIFF
--- a/blog/_posts/2015-10-23-auto-diff-in-julia.md
+++ b/blog/_posts/2015-10-23-auto-diff-in-julia.md
@@ -181,7 +181,7 @@ Here's the definition of the function in Julia:
 
 # Performance Comparison: The Results
 
-The benchmarks were performed with input vectors of length 16, 1600, and 16000, taking the best time out of 5 trials for each test. I ran them on a late 2013 MacBook Pro (OSX 10.9.5, 2.6 GHz Intel Core i5, 8 GB 1600 MHz DDR3) with the following versions of the relevant libraries: Julia v0.4.1-pre+15, Python v2.7.9, ForwardDiff.jl v0.1.2, Calculus.jl v0.1.13, and AlgoPy v0.5.1.
+The benchmarks were performed with input vectors of length 16, 1600, and 16000, taking the best time out of 5 trials for each test. I ran them on a late 2013 MacBook Pro (macOS 10.9.5, 2.6 GHz Intel Core i5, 8 GB 1600 MHz DDR3) with the following versions of the relevant libraries: Julia v0.4.1-pre+15, Python v2.7.9, ForwardDiff.jl v0.1.2, Calculus.jl v0.1.13, and AlgoPy v0.5.1.
 
 Let's start by looking at the evaluation times of `ackley(x)` in both Python and Julia:
 

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -26,7 +26,7 @@ JuliaBox, all of these plotting packages are pre-installed.
     <td colspan="3"> <a href="https://s3.amazonaws.com/julialang/bin/winnt/x64/0.5/julia-0.5.0-win64.exe">64-bit</a> </td>
 </tr>
 <tr>
-    <th> Mac OS X Package (.dmg) </th>
+    <th> macOS Package (.dmg) </th>
     <td colspan="6"> <a href="https://s3.amazonaws.com/julialang/bin/osx/x64/0.5/julia-0.5.0-osx10.7+.dmg">10.7+ 64-bit</a> </td>
 </tr>
 <tr>
@@ -78,7 +78,7 @@ are advised to use the latest official release version of Julia, above.
     <td colspan="2"> <a href="https://status.julialang.org/download/win64">64-bit</a> </td>
 </tr>
 <tr>
-    <th> Mac OS X Package (.dmg) </th>
+    <th> macOS Package (.dmg) </th>
     <td colspan="3"> <a href="https://status.julialang.org/download/osx10.7+">10.7+ 64-bit</a> </td>
 </tr>
 <tr>
@@ -105,7 +105,7 @@ are advised to use the latest official release version of Julia, above.
 
 # Download verification
 All Julia binary releases are cryptographically secured using the traditional methods on each
-operating system platform.  OS X and Windows releases are codesigned by certificates that are
+operating system platform.  macOS and Windows releases are codesigned by certificates that are
 verified by the operating system before installation.  Generic Linux tarballs and source tarballs
 are signed via GPG using [this key](../juliareleases.asc).  Ubuntu and Fedora/RHEL/CentOS/SL
 releases are signed by their own keys that are verified by the package managers when installing.

--- a/downloads/oldreleases.md
+++ b/downloads/oldreleases.md
@@ -17,7 +17,7 @@ anymore.
     <td colspan="3"> <a href="https://s3.amazonaws.com/julialang/bin/winnt/x64/0.4/julia-0.4.7-win64.exe">64-bit</a> </td>
 </tr>
 <tr>
-    <th> Mac OS X Package (.dmg) </th>
+    <th> macOS Package (.dmg) </th>
     <td colspan="6"> <a href="https://s3.amazonaws.com/julialang/bin/osx/x64/0.4/julia-0.4.7-osx10.7+.dmg">10.7+ 64-bit</a> </td>
 </tr>
 <tr>
@@ -47,7 +47,7 @@ anymore.
     <td> <a href="https://s3.amazonaws.com/julialang/bin/winnt/x64/0.3/julia-0.3.12-win64.exe">64-bit</a> </td>
 </tr>
 <tr>
-    <th> Mac OS X Package (.dmg) </th>
+    <th> macOS Package (.dmg) </th>
     <td colspan="2"> <a href="https://s3.amazonaws.com/julialang/bin/osx/x64/0.3/julia-0.3.12-osx10.7+.dmg">10.7+ 64-bit</a> </td>
 </tr>
 <tr>
@@ -79,7 +79,7 @@ anymore.
   <td> <a href="https://junolab.s3.amazonaws.com/release/1.0.3/juno-windows-x64.zip">64-bit</a> </td>
 </tr>
 <tr>
-  <th> Mac OS X (10.8+)</th>
+  <th> macOS (10.8+)</th>
   <td colspan="2"> <a href="https://junolab.s3.amazonaws.com/release/1.0.3/juno-mac-x64.dmg">64-bit</a> </td>
 </tr>
 <tr>
@@ -99,7 +99,7 @@ anymore.
     <td> <a href="http://s3.amazonaws.com/julialang/bin/winnt/x64/0.2/julia-0.2.1-win64.exe">64-bit</a> </td>
 </tr>
 <tr>
-    <th> Mac OS X Package (.dmg) </th>
+    <th> macOS Package (.dmg) </th>
     <td> <a href="https://s3.amazonaws.com/julialang/bin/osx/x64/0.2/julia-0.2.1-osx10.6.dmg">10.6 64-bit</a> </td>
     <td> <a href="https://s3.amazonaws.com/julialang/bin/osx/x64/0.2/julia-0.2.1-osx10.7+.dmg">10.7+ 64-bit</a> </td>
 </tr>
@@ -123,7 +123,7 @@ anymore.
     <td> 64-bit (Unavailable) </td>
 </tr>
 <tr>
-    <th> Mac OS X Package (.dmg) </th>
+    <th> macOS Package (.dmg) </th>
     <td>32-bit (Unavailable)</td>
     <td> <a href="http://julialang.googlecode.com/files/Julia-0.1.2.dmg">64-bit</a> </td>
 </tr>

--- a/downloads/platform.md
+++ b/downloads/platform.md
@@ -19,7 +19,7 @@ Uninstallation is performed by deleting the extracted directory and the packages
 
 ## macOS
 
-On Mac, a Julia-version.dmg file is provided, which contains Julia.app. Installation is the same as any other Mac software -- copy the Julia.app to your hard-drive (anywhere) or run from the disk image. Julia supports all macOS 10.7 and later. If you use Snow Leopard (macOS 10.6), Julia 0.2.1 was the last release of Julia that supported it.
+On Mac, a Julia-version.dmg file is provided, which contains Julia.app. Installation is the same as any other Mac software -- copy the Julia.app to your hard-drive (anywhere) or run from the disk image. Julia supports all OS X 10.7 and later. If you use Snow Leopard (OS X 10.6), Julia 0.2.1 was the last release of Julia that supported it.
 
 Uninstall Julia by deleting Julia.app and the packages directory in ~/.julia. Multiple Julia.app binaries can co-exist without interfering with each other. If you would also like to remove your preferences files, remove `~/.juliarc.jl`.
 

--- a/downloads/platform.md
+++ b/downloads/platform.md
@@ -17,9 +17,9 @@ The [Windows README](https://github.com/JuliaLang/julia/blob/master/README.windo
 
 Uninstallation is performed by deleting the extracted directory and the packages directory in `%HOME%/.julia`. If you would also like to remove your preferences files, remove `%HOME%/.juliarc.jl` and `%HOME%/.julia_history`.
 
-## OS X
+## macOS
 
-On Mac, a Julia-version.dmg file is provided, which contains Julia.app. Installation is the same as any other Mac software -- copy the Julia.app to your hard-drive (anywhere) or run from the disk image. Julia supports all OS X 10.7 and later. If you use Snow Leopard (OSX 10.6), Julia 0.2.1 was the last release of Julia that supported it.
+On Mac, a Julia-version.dmg file is provided, which contains Julia.app. Installation is the same as any other Mac software -- copy the Julia.app to your hard-drive (anywhere) or run from the disk image. Julia supports all macOS 10.7 and later. If you use Snow Leopard (macOS 10.6), Julia 0.2.1 was the last release of Julia that supported it.
 
 Uninstall Julia by deleting Julia.app and the packages directory in ~/.julia. Multiple Julia.app binaries can co-exist without interfering with each other. If you would also like to remove your preferences files, remove `~/.juliarc.jl`.
 


### PR DESCRIPTION
macOS (10.12) is released today.

This pull request replaces Mac OS X, OS X, OSX, etc. with macOS to be consistent with the new OS.