### PR TITLE
added a SEPS 2016  publication (Amsterdam, part of SPLASH)

### DIFF
--- a/publications/_EDIT_ME_index.md
+++ b/publications/_EDIT_ME_index.md
@@ -116,6 +116,8 @@ requests](https://github.com/JuliaLang/julialang.github.com/).
 
 [@RSLLBHGL16]
 
+[@PK16]
+
 # Theses
 
 [@V14]

--- a/publications/julia.bib
+++ b/publications/julia.bib
@@ -527,3 +527,35 @@ abstract = { Matrix Depot is a Julia software package that provides
                   of the numeric data types supported by the language.
                   }
 }
+
+@inproceedings{PK16,
+ author = {Kourzanov, Peter},
+ title = {Parallel Evaluation of a DSP Algorithm Using Julia},
+ booktitle = {Proceedings of the 3rd International Workshop on
+Software Engineering for Parallel Systems},
+ series = {SEPS 2016},
+ year = {2016},
+ isbn = {978-1-4503-4641-2},
+ location = {Amsterdam, Netherlands},
+ pages = {20--24},
+ numpages = {5},
+ url = {http://doi.acm.org/10.1145/3002125.3002126},
+ doi = {10.1145/3002125.3002126},
+ acmid = {3002126},
+ publisher = {ACM},
+ address = {New York, NY, USA},
+ keywords = {HLS, Julia, LSF, MapReduce, SystemC},
+ abstract = { Rapid pace of innovation in industrial research labs
+requires fast algorithm evaluation cycles. The use of multi-core
+hardware and distributed clusters is essential to achieve reasonable
+turnaround times for high-load simulations. Julia’s support for these
+as well as its pervasive multiple dispatch make it very attractive for
+high-performance technical computing.
+
+Our experiments in speeding up a Digital Signal Processing (DSP)
+Intellectual Property (IP) model simulation for a Wireless LAN (WLAN)
+product confirm this. We augment standard SystemC High-Level Synthesis
+(HLS) tool-flow by an interactive worksheet supporting performance
+visualization and rapid design space exploration cycles. }
+} 
+


### PR DESCRIPTION
Hi!

I have recently published and presented a new paper about Julia's support for hybrid computing.
The venue was SPLASH (in particular, SEPS workshop) that was held in Amsterdam Oct 30-Nov 4.
Corresponding BiBTeX has been updated.

Kind regards,
Peter