### PR TITLE
Add GGPlots.jl project

### DIFF
--- a/soc/ideas-page.md
+++ b/soc/ideas-page.md
@@ -356,6 +356,7 @@ A possible mentor can be contacted on the julia-users mailing list.
 - Adding recipes for statistics, machine learning (see [MLPlots.jl](https://github.com/JuliaML/MLPlots.jl)), or any other fields which you have an interest.
 - Documentation and/or tutorials.
 - Better integration with Graphs, DataStreams, etc
+- Improved support for the Grammar of Graphics API in Plots.jl via GGPlots.jl
  
 # Theme: Machine Learning Frameworks
 

--- a/soc/ideas-page.md
+++ b/soc/ideas-page.md
@@ -352,11 +352,11 @@ A possible mentor can be contacted on the julia-users mailing list.
 
 [Plots.jl](https://github.com/tbreloff/Plots.jl) has become the preferred graphical interface for many users.  It has the potential to become the standard Julia interface for data visualization, and there are many potential ways that a student could contribute:
 
-- Expanding backend support.  Integration with real-time visualization platforms (GLVisualize).  Easy latex plotting for scientific research publications (PGFPlots).
+- Expanding backend support.  Integration with real-time visualization platforms ([GLVisualize.jl](https://github.com/JuliaGL/GLVisualize.jl)).  Easy latex plotting for scientific research publications ([PGFPlots.jl](https://github.com/sisl/PGFPlots.jl)).
 - Adding recipes for statistics, machine learning (see [MLPlots.jl](https://github.com/JuliaML/MLPlots.jl)), or any other fields which you have an interest.
 - Documentation and/or tutorials.
-- Better integration with Graphs, DataStreams, etc
-- Improved support for the Grammar of Graphics API in Plots.jl via GGPlots.jl
+- Better integration with Graphs, DataStreams, etc.
+- Improved support for the Grammar of Graphics API in Plots.jl via [GGPlots.jl](https://github.com/JuliaPlots/GGPlots.jl).
  
 # Theme: Machine Learning Frameworks
 


### PR DESCRIPTION
GGPlots.jl adds a grammar of graphics API to Plots.jl. @tbreloff already has some starter code though there's still more to do, making it an easy project to get started with. But given chats with people throughout the ecosystem, many people are holdouts on Plots.jl until it has this style of API (I guess a lot of data scientists really like it?) so it would be a very big gain for Jullia.