### PR TITLE
DiffEqDiffTools project

### DIFF
--- a/soc/ideas-page.md
+++ b/soc/ideas-page.md
@@ -177,6 +177,41 @@ This project proposal is to implement a native Julia framework for distributed e
 
 # Theme: Numerical Methods for Differential Equations
 
+## DiffEq-specific differentiation library to ease development of fast native stiff solvers
+
+Methods for solving stiff differential equations and differential algebraic equations
+(DAEs) are composed of similar calculus objects: gradients, Jacobians, etc. However,
+not only are these objects common, but there are also very common use patterns.
+For example, the quantity `(M - gamma*J)^(-1)`, (where `M` is a mass matrix, `J`
+is the Jacobian, and `gamma` is a constant), is found in Rosenbrock methods,
+Newton solvers for implicit Runge-Kutta methods, and update equations for
+implicit multistep methods. However, the current setup requires that every solver
+implements these functions on their own, leaving the chosen options and optimizations
+as repeated work throughout the ecosystem.
+
+The goal would be to create a library which exposes many different options
+for computing these quantities to allow for easier development of native solvers.
+Specifically, [ParameterizedFunctions.jl](https://github.com/JuliaDiffEq/ParameterizedFunctions.jl)
+symbolically computes explicit functions for these quantities in many cases,
+and the user can also specify the functions. But if no function is found,
+then the library functions can must provide fallbacks using 
+[ForwardDiff.jl](https://github.com/JuliaDiff/ForwardDiff.jl)
+and [ReverseDiff.jl](https://github.com/JuliaDiff/ReverseDiff.jl) for autodifferentiation,
+and [Calculus.jl](https://github.com/johnmyleswhite/Calculus.jl) for a fallback
+when numerical differentiation most be used. Using the traits provided by
+[DiffEqBase.jl](https://github.com/JuliaDiffEq/DiffEqBase.jl), this can all be
+implemented with zero runtime overhead, utilizing Julia's JIT compiler to choose the
+correct method at compile-time.
+
+Students who take on this project will encounter and utilize many of the core
+tools for scientific computing in Julia, and the result will be a very useful
+library for all differential equation solvers.
+
+For more details, see
+[the following issue](https://github.com/JuliaDiffEq/DiffEqDiffTools.jl/issues/1).
+
+**Expected Results**: A high-performance backend library for native differential equation solvers.
+
 ## Native Julia solvers for ordinary differential equations and algebraic differential equations
 
 Julia needs to have a full set of ordinary differential equations (ODE) and algebraic differential equation (DAE) solvers, as they are vital for numeric programming. There are many advantages to having a native Julia implementation, including the ability to use Julia-defined types (for things like arbitrary precision) and composability with other packages. A library of methods can be built for the common interface, seamlessly integrating with the other available methods. Possible families of methods to implement are:
@@ -217,17 +252,10 @@ One of the major uses for differential equations solvers is for partial differen
 
 **Expected Results**: A production-quality PDE solver package for some common PDEs.
 
-## Solving partial differential equations discretized via spectral methods
-
-[ApproxFun.jl](https://github.com/JuliaApproximation/ApproxFun.jl) provides tools which can discretize many partial differential equations using spectral methods which have exponential convergence and thus low error. However, to solve time-dependent problems, these tools have to be paired with ODE solvers. While a fixed-basis discretization is currently able to be solved, it is more efficient to allow the spectral methods to adapt the basis as necessary for error control. However, this means that the differential equation must be solved where the input is not an array, but a nontrivial Julia-defined type. The goal would be to extend [OrdinaryDiffEq.jl](https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl) to be able to directly handle `Fun` types.
-
-**Expected Results**: Native support in OrdinaryDiffEq.jl for ODEs defined on ApproxFun.jl `Fun`s.
-
 ## Improved plotting for differential equations
 
 Plotting is a fundamental tool for analyzing the numerical solutions to differential equations. The plotting functionality in JuliaDiffEq is provided by plot recipes to [Plots.jl](https://github.com/tbreloff/Plots.jl) which create plots directly from the differential equation solution types. However, this functionality is currently limited. Some goals for this project would be:
 
-- A more refined default method for ODEs, which allows one to control which system components are plotted and plot phase plots.
 - The ability to pass the triangular mesh into Plots.jl. This is essential for plotting the solutions to finite element PDE discretizations on non-convex domains.
 - Methods for visualizing ODEs which change size.
 - Visualizations for results of parameter sensitivity analysis and parameter estimation.


### PR DESCRIPTION
This adds a new project to the differential equations section which is to build a library of differentiation tools for native differential equation solvers. This is a very self-contained project which should take about a month or 2 depending on experience, but would expose the student to all sorts of Julia libraries like ForwardDiff/ReverseDiff, Calculus, and SymEngine, with the final project being a major win for JuliaDiffEq (and some components may be useful in other places in scientific computing). I don't think that getting started on this is very hard, and so I think this is the best GSoC project for JuliaDiffEq. Because of that, I put it on the top of the JuliaDiffEq part. [More details are laid out here.](https://github.com/JuliaDiffEq/DiffEqDiffTools.jl/issues/1)

To not take up too much space, I removed the project on using ApproxFuns with the DiffEq solvers. This project may take more Julia type system expertise than one could expect from a GSoC student. Also, a plotting functionality was removed because someone recently put in a PR which implemented it!