### PR TITLE
Modify DiffEq projects: natural syntax parsing

### DIFF
--- a/soc/ideas-page.md
+++ b/soc/ideas-page.md
@@ -177,6 +177,41 @@ This project proposal is to implement a native Julia framework for distributed e
 
 # Theme: Numerical Methods for Differential Equations
 
+## DiffEq-specific differentiation library to ease development of fast native stiff solvers
+
+Methods for solving stiff differential equations and differential algebraic equations
+(DAEs) are composed of similar calculus objects: gradients, Jacobians, etc. However,
+not only are these objects common, but there are also very common use patterns.
+For example, the quantity `(M - gamma*J)^(-1)`, (where `M` is a mass matrix, `J`
+is the Jacobian, and `gamma` is a constant), is found in Rosenbrock methods,
+Newton solvers for implicit Runge-Kutta methods, and update equations for
+implicit multistep methods. However, the current setup requires that every solver
+implements these functions on their own, leaving the chosen options and optimizations
+as repeated work throughout the ecosystem.
+
+The goal would be to create a library which exposes many different options
+for computing these quantities to allow for easier development of native solvers.
+Specifically, [ParameterizedFunctions.jl](https://github.com/JuliaDiffEq/ParameterizedFunctions.jl)
+symbolically computes explicit functions for these quantities in many cases,
+and the user can also specify the functions. But if no function is found,
+then the library functions can must provide fallbacks using 
+[ForwardDiff.jl](https://github.com/JuliaDiff/ForwardDiff.jl)
+and [ReverseDiff.jl](https://github.com/JuliaDiff/ReverseDiff.jl) for autodifferentiation,
+and [Calculus.jl](https://github.com/johnmyleswhite/Calculus.jl) for a fallback
+when numerical differentiation most be used. Using the traits provided by
+[DiffEqBase.jl](https://github.com/JuliaDiffEq/DiffEqBase.jl), this can all be
+implemented with zero runtime overhead, utilizing Julia's JIT compiler to choose the
+correct method at compile-time.
+
+Students who take on this project will encounter and utilize many of the core
+tools for scientific computing in Julia, and the result will be a very useful
+library for all differential equation solvers.
+
+For more details, see
+[the following issue](https://github.com/JuliaDiffEq/DiffEqDiffTools.jl/issues/1).
+
+**Expected Results**: A high-performance backend library for native differential equation solvers.
+
 ## Native Julia solvers for ordinary differential equations and algebraic differential equations
 
 Julia needs to have a full set of ordinary differential equations (ODE) and algebraic differential equation (DAE) solvers, as they are vital for numeric programming. There are many advantages to having a native Julia implementation, including the ability to use Julia-defined types (for things like arbitrary precision) and composability with other packages. A library of methods can be built for the common interface, seamlessly integrating with the other available methods. Possible families of methods to implement are:
@@ -217,17 +252,10 @@ One of the major uses for differential equations solvers is for partial differen
 
 **Expected Results**: A production-quality PDE solver package for some common PDEs.
 
-## Solving partial differential equations discretized via spectral methods
-
-[ApproxFun.jl](https://github.com/JuliaApproximation/ApproxFun.jl) provides tools which can discretize many partial differential equations using spectral methods which have exponential convergence and thus low error. However, to solve time-dependent problems, these tools have to be paired with ODE solvers. While a fixed-basis discretization is currently able to be solved, it is more efficient to allow the spectral methods to adapt the basis as necessary for error control. However, this means that the differential equation must be solved where the input is not an array, but a nontrivial Julia-defined type. The goal would be to extend [OrdinaryDiffEq.jl](https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl) to be able to directly handle `Fun` types.
-
-**Expected Results**: Native support in OrdinaryDiffEq.jl for ODEs defined on ApproxFun.jl `Fun`s.
-
 ## Improved plotting for differential equations
 
 Plotting is a fundamental tool for analyzing the numerical solutions to differential equations. The plotting functionality in JuliaDiffEq is provided by plot recipes to [Plots.jl](https://github.com/tbreloff/Plots.jl) which create plots directly from the differential equation solution types. However, this functionality is currently limited. Some goals for this project would be:
 
-- A more refined default method for ODEs, which allows one to control which system components are plotted and plot phase plots.
 - The ability to pass the triangular mesh into Plots.jl. This is essential for plotting the solutions to finite element PDE discretizations on non-convex domains.
 - Methods for visualizing ODEs which change size.
 - Visualizations for results of parameter sensitivity analysis and parameter estimation.

--- a/soc/ideas-page.md
+++ b/soc/ideas-page.md
@@ -153,7 +153,7 @@ for computing these quantities to allow for easier development of native solvers
 Specifically, [ParameterizedFunctions.jl](https://github.com/JuliaDiffEq/ParameterizedFunctions.jl)
 symbolically computes explicit functions for these quantities in many cases,
 and the user can also specify the functions. But if no function is found,
-then the library functions can must provide fallbacks using
+then the library functions can provide fallbacks using
 [ForwardDiff.jl](https://github.com/JuliaDiff/ForwardDiff.jl)
 and [ReverseDiff.jl](https://github.com/JuliaDiff/ReverseDiff.jl) for autodifferentiation,
 and [Calculus.jl](https://github.com/johnmyleswhite/Calculus.jl) for a fallback

--- a/soc/ideas-page.md
+++ b/soc/ideas-page.md
@@ -194,7 +194,7 @@ for computing these quantities to allow for easier development of native solvers
 Specifically, [ParameterizedFunctions.jl](https://github.com/JuliaDiffEq/ParameterizedFunctions.jl)
 symbolically computes explicit functions for these quantities in many cases,
 and the user can also specify the functions. But if no function is found,
-then the library functions can must provide fallbacks using 
+then the library functions can must provide fallbacks using
 [ForwardDiff.jl](https://github.com/JuliaDiff/ForwardDiff.jl)
 and [ReverseDiff.jl](https://github.com/JuliaDiff/ReverseDiff.jl) for autodifferentiation,
 and [Calculus.jl](https://github.com/johnmyleswhite/Calculus.jl) for a fallback
@@ -211,6 +211,30 @@ For more details, see
 [the following issue](https://github.com/JuliaDiffEq/DiffEqDiffTools.jl/issues/1).
 
 **Expected Results**: A high-performance backend library for native differential equation solvers.
+
+## Natural syntax parsing and symbolic transformations of differential equations
+
+[ParameterizedFunctions.jl](https://github.com/JuliaDiffEq/ParameterizedFunctions.jl)
+is a component of the JuliaDiffEq ecosystem that allows for users to define differential
+equations in a natural syntax (with parameters). The benefits of this setup are threefold:
+
+- The existence of parameters allows for optimization / machine learning techniques
+  to be applied to and learn parameters from data.
+- The natural syntax allows [DifferentialEquations.jl Online](http://app.juliadiffeq.org/)
+  to have a user-friendly programming-free frontend.
+- The setup allows for [SymEngine.jl](https://github.com/symengine/SymEngine.jl)
+  to symbolically calculate various mathematical objects to speed up the solvers.
+
+However, the macros are currently only able to parse ordinary differential equations (ODEs)
+and stochastic differential equations (SDEs). An extension to the language and parser
+will need to be introduced in order to handle differential algebraic equations (DAEs)
+and delay differential equations (DDEs). In addition, symbolic enhancements could
+be applied to automatically lower the index of the DAEs and transform delay equations
+into larger systems of ODEs, greatly increasing the amount of equations which can
+be easily solved. Finally, this improved parser can be used to develop new pages
+for DifferentialEquations.jl Online for solving DAEs and DDEs.
+
+**Expected Results**: An improved parser within the macro which supports delay and algebraic differential equations.
 
 ## Native Julia solvers for ordinary differential equations and algebraic differential equations
 
@@ -251,16 +275,6 @@ Bayesian estimation of parameters for differential equations is a popular techni
 One of the major uses for differential equations solvers is for partial differential equations (PDEs). PDEs are solved by discretizing to create ODEs which are then solved using ODE solvers. However, in many cases a good understanding of the PDEs are required to perform this discretization and minimize the error. The purpose of this project is to produce a library with common PDE discretizations to make it easier for users to solve common PDEs.
 
 **Expected Results**: A production-quality PDE solver package for some common PDEs.
-
-## Improved plotting for differential equations
-
-Plotting is a fundamental tool for analyzing the numerical solutions to differential equations. The plotting functionality in JuliaDiffEq is provided by plot recipes to [Plots.jl](https://github.com/tbreloff/Plots.jl) which create plots directly from the differential equation solution types. However, this functionality is currently limited. Some goals for this project would be:
-
-- The ability to pass the triangular mesh into Plots.jl. This is essential for plotting the solutions to finite element PDE discretizations on non-convex domains.
-- Methods for visualizing ODEs which change size.
-- Visualizations for results of parameter sensitivity analysis and parameter estimation.
-
-**Expected Results**: Publication-quality plot recipes.
 
 # Theme: Numerical Linear Algebra
 


### PR DESCRIPTION
One last modification to the JuliaDiffEq projects. I removed the JuliaDiffEq plotting project because overtime other contributors keep chipping away at it so I don't think there's a summer left there. However, this new project is a very good opportunity. We will be launching DifferentialEquations.jl online soon:

http://app.juliadiffeq.org/

and realized that we need to expand the functionality of ParameterizedFunctions.jl to be able to parse delay differential equations and differential-algebraic equations. So the start of the project is simple to describe: expand the parse-able syntax of the ParameterizedFunctions.jl macros to allow for these types of equations, but an advanced student can go a lot of places from here, including:

- Add DAEs and DDEs to DifferentialEquations.jl Online
- Allow the macros to perform automatic index reduction on DAEs
- Modify the symbolic calculations within the macro to define extensions to the Jacobians etc. for DAE solvers
- Provide the ability to reduce some DDEs to ODEs
- Check if the differential equation has a solution and, if it does, return that analytical solution
- Expand DiffEqProblemLibrary to contain many examples, both for testing and as a tutorial

Given that symbolic calculations are already performed in the macro using SymEngine.jl, there's essentially a tutorial for how to get started on all of these already within the source code. Thus the resulting project can go in more web, mathematical, computer science (parsing), or even scientific directions depending on the student.

(Note: do not share the DifferentialEquations.jl Online weblink yet as we still have some work to do before launching. Thus for now this is labelled WIP)