### PR TITLE
Edit on Github link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,7 +23,7 @@ navigation:
     title: teaching
   - url: "/publications/"
     title: publications
-  - url: "/soc/"
+  - url: "/soc/ideas-page.html"
     title: GSoC
   - url: "http://juliacon.org"
     title: juliacon

--- a/_includes/links.html
+++ b/_includes/links.html
@@ -7,7 +7,11 @@
       {% if page.url == '/' and item.url == '/' %}
           {% assign class = 'active' %}
       {% endif %}
-      <li><a href="{{ item.url }}" class="{{ class }}">{{ item.title }}</a></li>
+      {% assign prefix = site.baseurl %}
+      {% if item.url contains 'http://' or item.url contains 'https://' %}
+        {% assign prefix = nil %}
+      {% endif %}
+      <li><a href="{{ prefix }}{{ item.url }}" class="{{ class }}">{{ item.title }}</a></li>
   {% endfor %}
 </ul>
 

--- a/_layouts/common.html
+++ b/_layouts/common.html
@@ -16,7 +16,7 @@
     ga('create', 'UA-28835595-1', 'auto');
     ga('send', 'pageview');
   </script>
-  
+
   <script type="text/javascript">window.liveSettings={api_key:"ab25420d08984953bd7435fd47506f96"};</script>
   <script type="text/javascript" src="//cdn.transifex.com/live.js"></script>
 </head>
@@ -24,7 +24,7 @@
 <div id="site" class="site">
 {{ content }}
 <div class="footer">
-Julia is a <a href="http://numfocus.org/projects/index.html">NumFocus project</a>.
+Julia is a <a href="http://numfocus.org/projects/index.html">NumFocus project</a>. <a href="https://github.com/JuliaLang/julialang.github.com/blob/master/{{ page.path }}">Edit this page on GitHub.</href>
 </div>
 
 <!--Flipcause Integration v3.0// Flipcause Integration Instructions:
@@ -174,7 +174,6 @@ Julia is a <a href="http://numfocus.org/projects/index.html">NumFocus project</a
 </div>
 
 <!--END Flipcause Main Integration Code-->
-
 
 <div style="background:#ccc; border-radius:0px 0px 0px 0px;font-weight:normal; font-family:Arial, Helvetica, sans-serif;border:none;box-shadow:none;left: 50%; margin-left:-72.5px;clear: both;display: block; width:145px;height:45px; line-height:2.8; position:relative; font-size:16px;text-align:center; cursor:pointer;color:#fff;text-decoration: none; z-index:1" onclick="open_window('MjI1Nw==')">Donate Now</div>
 </div>

--- a/_layouts/common.html
+++ b/_layouts/common.html
@@ -5,8 +5,8 @@
   <meta http-equiv="content-type" content="text/html; charset=utf-8" />
   <title>{{ page.title }}</title>
   <meta name="author" content="Jeff Bezanson, Stefan Karpinski, Viral Shah, Alan Edelman, et al." />
-  <link rel="stylesheet" href="/css/syntax.css" type="text/css" />
-  <link rel="stylesheet" href="/css/screen.css" type="text/css" media="screen, projection" />
+  <link rel="stylesheet" href="{{ site.baseurl }}/css/syntax.css" type="text/css" />
+  <link rel="stylesheet" href="{{ site.baseurl }}/css/screen.css" type="text/css" media="screen, projection" />
   <script>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),


### PR DESCRIPTION
Was just going to edit the gsoc page quickly and fell down a rabit hole. Anyway, this adds an "edit on github" link at the bottom of pages to make that a bit quicker / more accessible.

Also fixes a couple of urls to use relative references. This makes it easier to test a fork like [this](https://mikeinnes.github.io/julialang.github.com/); all the links and CSS don't break.