### PR TITLE
Fix link

### DIFF
--- a/blog/_posts/2017-01-21-moredots.md
+++ b/blog/_posts/2017-01-21-moredots.md
@@ -597,4 +597,4 @@ Sometimes, of course, their behavior coincides, e.g. `map(sqrt, [1,2,3])` and
 nor `broadcast` generalizes the other — each has things they can do that
 the other cannot.
 
-[notebook]: https://github.com/JuliaLang/julialang.github.com/blob/moredots/blog/_posts/moredots/More-Dots.ipynb
+[notebook]: https://github.com/JuliaLang/julialang.github.com/blob/master/blog/_posts/moredots/More-Dots.ipynb


### PR DESCRIPTION
The link in the [blog post](http://julialang.org/blog/2017/01/2017-01-21-moredots) is broken and I suspect this is what was intended.