### PR TITLE
Remove colon from More Dots blog post title

### DIFF
--- a/blog/_posts/2017-01-21-moredots.md
+++ b/blog/_posts/2017-01-21-moredots.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title:  More Dots: Syntactic Loop Fusion in Julia
+title:  More Dots - Syntactic Loop Fusion in Julia
 author: <a href="http://math.mit.edu/~stevenj">Steven G. Johnson</a>
 ---
 


### PR DESCRIPTION
This attempts to fix the rendering problems by replacing a colon with a dash. Judging from previous posts (e.g. http://julialang.org/blog/2015/10/datastreams), we should also have been to get the colon to render by placing the title in quotes.