### PR TITLE
Add JuliaPro as a way to download Julia.

### DIFF
--- a/downloads/index.md
+++ b/downloads/index.md
@@ -12,9 +12,9 @@ We provide several ways for you to run Julia:
 * [JuliaPro](http://juliacomputing.com/products/juliapro.html) by [Julia Computing](http://juliacomputing.com) is a batteries included distribution of Julia. It includes the [Juno IDE](http://junolab.org), the [Gallium debugger](https://github.com/Keno/Gallium.jl), and a number of packages for plotting, optimization, machine learning, databases and much more (requires registration).
 
 Plotting capabilities are provided by external packages such as
-[PyPlot.jl](https://github.com/stevengj/PyPlot.jl) and [Gadfly.jl](http://gadflyjl.org).
+[PyPlot.jl](https://github.com/JuliaPy/PyPlot.jl) and [Gadfly.jl](http://gadflyjl.org).
 A package which integrates most of Julia's plotting backends into one convenient and
-well-documented API is [Plots.jl](https://github.com/tbreloff/Plots.jl). Look at the
+well-documented API is [Plots.jl](https://github.com/JuliaPlots/Plots.jl). Look at the
 [plotting instructions](plotting.html) to install a plotting package. If you are using
 JuliaBox, all of these plotting packages are pre-installed.
 

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -8,14 +8,14 @@ title:  Julia Downloads
 We provide several ways for you to run Julia:
 
 * In the terminal using the built-in Julia command line.
-* The [Juno](http://www.junolab.org) integrated development environment (IDE).
 * In the browser on [JuliaBox.com](https://www.juliabox.com) with Jupyter notebooks. No installation is required -- just point your browser there, login and start computing.
+* The [JuliaPro distribution](http://juliacomputing.com/products/juliapro.html) by Julia Computing provides a single installer for Julia, the [Juno IDE](http://junolab.org), the Gallium debugger, and a number of packages (requires registration).
 
 Plotting capabilities are provided by external packages such as
-[PyPlot.jl](https://github.com/stevengj/PyPlot.jl) and [Gadfly.jl](http://gadflyjl.org). 
-A package which integrates most of Julia's plotting backends into one convenient and 
-well-documented API is [Plots.jl](https://github.com/tbreloff/Plots.jl). Look at the 
-[plotting instructions](plotting.html) to install a plotting package. If you are using 
+[PyPlot.jl](https://github.com/stevengj/PyPlot.jl) and [Gadfly.jl](http://gadflyjl.org).
+A package which integrates most of Julia's plotting backends into one convenient and
+well-documented API is [Plots.jl](https://github.com/tbreloff/Plots.jl). Look at the
+[plotting instructions](plotting.html) to install a plotting package. If you are using
 JuliaBox, all of these plotting packages are pre-installed.
 
 ## Julia (command line version)
@@ -53,10 +53,6 @@ trouble installing Julia.  Checksums for this release are available in both [MD5
 If the provided download files do not work for you, please [file an
 issue in the Julia project](https://github.com/JuliaLang/julia/issues).
 
-## Juno IDE
-
-Please see the [Juno website](http://junolab.org) for setup instructions, and [the discussion forum](http://discuss.junolab.org) for any questions or issues.
-
 # Older Releases
 
 Older releases of Julia for all platforms are available on the [Older releases page](http://julialang.org/downloads/oldreleases.html).
@@ -66,8 +62,8 @@ For Julia 0.4, only bugfixes are being supported. Releases older than 0.4 are no
 # Nightly builds
 
 These are bleeding-edge binaries of the latest version of Julia under
-development, which you can use to get a preview of the latest work.  
-The nightly builds are for developer previews and not intended for 
+development, which you can use to get a preview of the latest work.
+The nightly builds are for developer previews and not intended for
 normal use. You can expect many packages not to work with this version.
 Most users are advised to use the latest official release version of Julia, above.
 

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -9,7 +9,7 @@ We provide several ways for you to run Julia:
 
 * In the terminal using the built-in Julia command line.
 * In the browser on [JuliaBox.com](https://www.juliabox.com) with Jupyter notebooks. No installation is required -- just point your browser there, login and start computing.
-* The [JuliaPro distribution](http://juliacomputing.com/products/juliapro.html) by Julia Computing provides a single installer for Julia, the [Juno IDE](http://junolab.org), the Gallium debugger, and a number of packages (requires registration).
+* [JuliaPro](http://juliacomputing.com/products/juliapro.html) by [Julia Computing](http://juliacomputing.com) is a batteries included distribution of Julia. It includes the [Juno IDE](http://junolab.org), the [Gallium debugger](https://github.com/Keno/Gallium.jl), and a number of packages for plotting, optimization, machine learning, databases and much more (requires registration).
 
 Plotting capabilities are provided by external packages such as
 [PyPlot.jl](https://github.com/stevengj/PyPlot.jl) and [Gadfly.jl](http://gadflyjl.org).

--- a/downloads/plotting.md
+++ b/downloads/plotting.md
@@ -9,7 +9,7 @@ Plotting in Julia is available through external packages.
 
 ## Plots
 
-[Plots.jl](https://github.com/tbreloff/Plots.jl) is a plotting metapackage which
+[Plots.jl](https://github.com/JuliaPlots/Plots.jl) is a plotting metapackage which
 brings many different plotting packages under a single API, making it easy to swap
 between plotting "backends". Installation and example usage is as follows:
 
@@ -32,7 +32,7 @@ visualizations the extension packages have added to Plots.jl.
 
 ## PyPlot
 
-[PyPlot](https://github.com/stevengj/PyPlot.jl) uses the Julia PyCall
+[PyPlot](https://github.com/JuliaPy/PyPlot.jl) uses the Julia PyCall
 package to call Python's matplotlib directly from Julia with little or
 no overhead (arrays are passed without making a copy). Make sure that
 Python and MatPlotlib are correctly installed. Installation of
@@ -60,6 +60,4 @@ draw(SVG("output.svg", 6inch, 3inch), plot([sin, cos], 0, 25))
 
 Gadfly's interface will be familiar to users of R's
 [ggplot2](http://ggplot2.org) package. See
-[examples](https://github.com/dcjones/Gadfly.jl/tree/master/doc) and
-documentation on the [Gadfly](https://github.com/dcjones/Gadfly.jl)
-homepage.
+examples documentation on the [Gadfly](http://gadflyjl.org) homepage.

--- a/downloads/plotting.md
+++ b/downloads/plotting.md
@@ -60,4 +60,4 @@ draw(SVG("output.svg", 6inch, 3inch), plot([sin, cos], 0, 25))
 
 Gadfly's interface will be familiar to users of R's
 [ggplot2](http://ggplot2.org) package. See
-examples documentation on the [Gadfly](http://gadflyjl.org) homepage.
+examples and documentation on the [Gadfly](http://gadflyjl.org) homepage.


### PR DESCRIPTION
We've been working on JuliaPro for a while, and it is now quite robust and easy to use and install. Adding it here as an option for others to have an alternative way.