### PR TITLE
Remove LearnBase from SoC

### DIFF
--- a/soc/projects/general.md
+++ b/soc/projects/general.md
@@ -7,20 +7,6 @@ title:  General Projects – Summer of Code
 
 {% include toc.html %}
 
-## Expanding and improving LearnBase/JuliaML
-
-[LearnBase](https://github.com/Evizero/LearnBase.jl) is an attempt to create common abstractions and tools for machine learning frameworks. Common functionality like data loading, loss functions or training processes can be defined generically, and then easily combined with a specific approach (e.g. an SVM).
-
-Possible projects are:
-  * Contributing to the generic functionality in JuliaML (e.g. creating or improving a package for loading data sets, or implementing training process, etc)
-  * Pure-Julia implementations of specific model types (e.g. decision trees or SVMs) which integrate with the JuliaML ecosystem.
-
-**Required Skills**: Knowledge of the machine learning technique(s) to be implemented.
-
-**Recommended Skills**: General knowledge of the JuliaML project and aims, or wide knowledge of machine learning as a field, is a plus.
-
-**Mentors**: [Christof Stocker](https://github.com/Evizero), [JuliaML Members](https://github.com/orgs/JuliaML/people)
-
 ## Standardized dataset packaging
 
 Scientific and technical computing often makes use of publicly available datasets. Often, there's a lot of overhead to finding these data sets and coercing them into a usable format. Packages like [RDatasets.jl](https://github.com/johnmyleswhite/RDatasets.jl/) and [MNIST.jl](https://github.com/johnmyleswhite/MNIST.jl) attempt to make this easier by downloading data automatically and providing it as a Julia data structure.


### PR DESCRIPTION
I am sorry to say, but I just today discovered I am listed as a SoC Mentor which I new nothing about. While I am always happy to help out at Projects I am involved in, I do not think I can promise the time to take on the responsibilities of being an official Mentor. I don't think a promise like this should be made so lightly.

There must have been an internal miscommunication along the line, because both "JuliaML" project ideas listed here are news to me. I am unsure what a SoC-length "LearnBase" project could even entail at this point, so maybe it is better to just remove the idea. I think to remember @tbreloff writing some text like this last year, so maybe it is some leftover text from the past?

I am sorry for this mixup. I am sure the intentions were good. I just don't want to make promises I probably can't keep.