### PR TITLE
Update minimum requirement info for macOS to 10.8 in download pages

### DIFF
--- a/downloads/index.md
+++ b/downloads/index.md
@@ -27,7 +27,7 @@ JuliaBox, all of these plotting packages are pre-installed.
 </tr>
 <tr>
     <th> macOS Package (.dmg) </th>
-    <td colspan="6"> <a href="https://s3.amazonaws.com/julialang/bin/osx/x64/0.5/julia-0.5.1-osx10.7+.dmg">10.7+ 64-bit</a> </td>
+    <td colspan="6"> <a href="https://s3.amazonaws.com/julialang/bin/osx/x64/0.5/julia-0.5.1-osx10.7+.dmg">10.8+ 64-bit</a> </td>
 </tr>
 <tr>
     <th> Generic Linux binaries </th>
@@ -75,7 +75,7 @@ Most users are advised to use the latest official release version of Julia, abov
 </tr>
 <tr>
     <th> macOS Package (.dmg) </th>
-    <td colspan="3"> <a href="https://status.julialang.org/download/osx10.7+">10.7+ 64-bit</a> </td>
+    <td colspan="3"> <a href="https://status.julialang.org/download/osx10.7+">10.8+ 64-bit</a> </td>
 </tr>
 <tr>
     <th> Generic Linux binaries </th>

--- a/downloads/platform.md
+++ b/downloads/platform.md
@@ -19,7 +19,7 @@ Uninstallation is performed by deleting the extracted directory and the packages
 
 ## macOS
 
-On Mac, a `Julia-<version>.dmg` file is provided, which contains Julia.app. Installation is the same as any other Mac software -- copy the `Julia-<version>.app` to your hard-drive (anywhere) or run from the disk image. Julia runs on macOS 10.7 and later releases.
+On Mac, a `Julia-<version>.dmg` file is provided, which contains Julia.app. Installation is the same as any other Mac software -- copy the `Julia-<version>.app` to your hard-drive (anywhere) or run from the disk image. Julia runs on macOS 10.8 and later releases.
 
 Uninstall Julia by deleting Julia.app and the packages directory in ~/.julia. Multiple Julia.app binaries can co-exist without interfering with each other. If you would also like to remove your preferences files, remove `~/.juliarc.jl`.
 


### PR DESCRIPTION
The macOS binaries don't work correctly on 10.7, see https://github.com/JuliaLang/julia/issues/20651 (which doesn't seem to be about to be fixed any time soon an most likely won't be fixed at all).

Although the binary would still have 10.7+ in the name, at least with this change the information on the website would be correct (I had a puzzled coworker wondering why `Pkg.add` was failing).