### PR TITLE
Add generic linux binary install instructions

### DIFF
--- a/downloads/index.md
+++ b/downloads/index.md
@@ -21,16 +21,16 @@ JuliaBox, all of these plotting packages are pre-installed.
 ## Julia (command line version)
 <table class="downloads"><tbody>
 <tr>
-    <th> Windows Self-Extracting Archive (.exe) </th>
+    <th> Windows Self-Extracting Archive (.exe) <a href="platform.html#windows">[help]</a></th>
     <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6.0-win32.exe">32-bit</a> </td>
     <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6.0-win64.exe">64-bit</a> </td>
 </tr>
 <tr>
-    <th> macOS Package (.dmg) </th>
+    <th> macOS Package (.dmg) <a href="platform.html#macos">[help]</a></th>
     <td colspan="6"> <a href="https://julialang-s3.julialang.org/bin/osx/x64/0.6/julia-0.6.0-osx10.7+.dmg">10.8+ 64-bit</a> </td>
 </tr>
 <tr>
-    <th> Generic Linux binaries </th>
+    <th> Generic Linux binaries <a href="platform.html#generic-linux-binaries">[help]</a></th>
     <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x86/0.6/julia-0.6.0-linux-i686.tar.gz">32-bit (X86)</a> (<a href="https://julialang-s3.julialang.org/bin/linux/x86/0.6/julia-0.6.0-linux-i686.tar.gz.asc">GPG</a>)</td>
     <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x64/0.6/julia-0.6.0-linux-x86_64.tar.gz">64-bit (X86)</a> (<a href="https://julialang-s3.julialang.org/bin/linux/x64/0.6/julia-0.6.0-linux-x86_64.tar.gz.asc">GPG</a>)</td>
 </tr>

--- a/downloads/platform.md
+++ b/downloads/platform.md
@@ -25,7 +25,21 @@ Uninstall Julia by deleting Julia.app and the packages directory in ~/.julia. Mu
 
 ## Linux
 
-It is strongly recommended that the official generic linux binaries from the downloads page be used to install Julia. The following distribution-specific packages are community contributed. They may not use the right versions of Julia dependencies or include important patches that the official binaries ship with. In general, bug reports will only be accepted if they are reproducible on the generic linux binaries on the downloads page.
+It is strongly recommended that the official generic linux binaries from the downloads page be used to install Julia. 
+
+### Generic Linux Binaries
+
+The generic linux binaries do not require any special installation steps, but you will need to ensure that your system can find the `julia` executable. To do that, you will need to extract the `.tar.gz` file downloaded from the [downloads page](index.html) to a folder on your computer, then either create a symbolic link to `julia` from a folder which is on your system `PATH` or add the `/bin` folder inside that archive to your system's `PATH` environment variable.
+
+As an example, to create a symbolic link to `julia` inside the `/usr/local/bin` folder, you can do the following:
+
+	sudo ln -s <where you extracted the julia archive>/bin/julia /usr/local/bin/julia
+
+On some linux distributions, you may need to use a folder other than `/usr/local/bin`. To check which folders are on your `PATH`, you can run `echo $PATH`. 
+
+### Linux Distribution-Specific Packages
+
+The following distribution-specific packages are community contributed. They may not use the right versions of Julia dependencies or include important patches that the official binaries ship with. In general, bug reports will only be accepted if they are reproducible on the generic linux binaries on the downloads page.
 
 Instructions will be added here as more linux distributions start including julia. If your Linux distribution is not listed here, you should still be able to run julia by building from source. See the [Julia README](https://github.com/JuliaLang/julia/blob/master/README.md) for more detailed information.
 

--- a/downloads/platform.md
+++ b/downloads/platform.md
@@ -33,7 +33,7 @@ The generic Linux binaries do not require any special installation steps, but yo
 
 * Create a symbolic link to `julia` inside a folder which is on your system `PATH`
 * Add Julia's `bin` folder to your system `PATH` environment variable
-* Invoke the `julia` executable by using it's full path, as in `<where you extracted Julia>/bin/julia`
+* Invoke the `julia` executable by using its full path, as in `<where you extracted Julia>/bin/julia`
 
 For example, to create a symbolic link to `julia` inside the `/usr/local/bin` folder, you can do the following:
 

--- a/downloads/platform.md
+++ b/downloads/platform.md
@@ -37,7 +37,7 @@ The generic Linux binaries do not require any special installation steps, but yo
 
 For example, to create a symbolic link to `julia` inside the `/usr/local/bin` folder, you can do the following:
 
-	sudo ln -s <where you extracted the julia archive>/bin/julia /usr/local/bin/julia
+    sudo ln -s <where you extracted the julia archive>/bin/julia /usr/local/bin/julia
 
 On some linux distributions, you may need to use a folder other than `/usr/local/bin`. To check which folders are on your `PATH`, you can run `echo $PATH`. 
 

--- a/downloads/platform.md
+++ b/downloads/platform.md
@@ -29,9 +29,13 @@ It is strongly recommended that the official generic linux binaries from the dow
 
 ### Generic Linux Binaries
 
-The generic linux binaries do not require any special installation steps, but you will need to ensure that your system can find the `julia` executable. To do that, you will need to extract the `.tar.gz` file downloaded from the [downloads page](index.html) to a folder on your computer, then either create a symbolic link to `julia` from a folder which is on your system `PATH` or add the `/bin` folder inside that archive to your system's `PATH` environment variable.
+The generic Linux binaries do not require any special installation steps, but you will need to ensure that your system can find the `julia` executable. First, extract the `.tar.gz` file downloaded from the [downloads page](index.html) to a folder on your computer. To run Julia, you can do any of the following:
 
-As an example, to create a symbolic link to `julia` inside the `/usr/local/bin` folder, you can do the following:
+* Create a symbolic link to `julia` inside a folder which is on your system `PATH`
+* Add Julia's `bin` folder to your system `PATH` environment variable
+* Invoke the `julia` executable by using it's full path, as in `<where you extracted Julia>/bin/julia`
+
+For example, to create a symbolic link to `julia` inside the `/usr/local/bin` folder, you can do the following:
 
 	sudo ln -s <where you extracted the julia archive>/bin/julia /usr/local/bin/julia
 


### PR DESCRIPTION
Fixes #525 

Also see https://discourse.julialang.org/t/getting-julia-running-on-atom/3932/5

I hope this is sufficiently clear, and that I've chosen the correct recommended installation steps. I'm happy to revise as needed. 

In addition, I've added direct "help" links from the downloads page for each of the major platform releases and release candidates. 