### PR TITLE
Add the EcoJulia organization

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -86,6 +86,7 @@ Various Julia projects are hosted under the following umbrella organizations on 
 ## Scientific Domains
 
 * [BioJulia](https://github.com/BioJulia) – Biology
+* [EcoJulia](https://github.com/EcoJulia) – Ecology
 * [JuliaAstro](https://github.com/JuliaAstro) – Astronomy
 * [JuliaDSP](https://github.com/JuliaDSP) – Digital signal processing
 * [JuliaQuant](https://github.com/JuliaQuant) – Finance


### PR DESCRIPTION
We've founded "EcoJulia", an organisation for Ecology in Julia. We're currently two members, Tim Poisot and myself, both university professors in Ecology who use Julia professionally, but we aim to expand. Our first Julia package (SpatialEcology.jl) has just been submitted to METADATA.

https://github.com/EcoJulia