### PR TITLE
Add a brief 0.6 release announcement blog post

### DIFF
--- a/blog/_posts/2017-06-27-julia-0.6-release.md
+++ b/blog/_posts/2017-06-27-julia-0.6-release.md
@@ -1,0 +1,25 @@
+---
+layout: post
+title:  Julia 0.6 Release Announcement
+author: The Julia Community
+---
+
+The Julia community is thrilled to announce the release of version 0.6.0 of the Julia language.
+With a sweeping overhaul of the type system and numerous improvements to syntax and to the
+standard library, 0.6.0 is the most transformative release yet.
+A comprehensive list of changes in this release is available in the main Julia repository in
+the [NEWS](https://github.com/JuliaLang/julia/blob/release-0.6/NEWS.md#julia-v060-release-notes)
+log.
+
+The 0.6 release line is now considered the stable line of releases and is recommended for most
+users, as it provides both language and API stability.
+As with previous versions, we will continue to update 0.6 with bugfixes, releasing subsequent
+0.6.x versions.
+Only critical bug fixes will be ported to 0.5 and releases older than 0.5 are now unmaintained.
+Work on new features is now taking place on the `master` branch for the 0.7 development cycle.
+
+Binaries are available for Linux, macOS, and Windows on the [main downloads
+page](https://julialang.org/downloads/).
+We encourage everyone to try it out.
+
+Happy coding!


### PR DESCRIPTION
Quite brief. We should also do a 0.6 highlights post as was done for 0.5, though we should get 0.6 release on JuliaBox with 0.6-specific syntax recognized in Jupyter first. That will make things look a little more polished.