### PR TITLE
Hygienic -> unhygienic

### DIFF
--- a/blog/_posts/2017-08-09-dsl.md
+++ b/blog/_posts/2017-08-09-dsl.md
@@ -314,7 +314,7 @@ function make_model(ex::Expr)
 end
 
 macro model(ex)
-    return esc(make_model(make_function(ex)))
+    return make_model(make_function(esc(ex)))
 end
 
 end

--- a/blog/_posts/2017-08-09-dsl.md
+++ b/blog/_posts/2017-08-09-dsl.md
@@ -290,7 +290,7 @@ julia> @macroexpand @model 2*a*x
 
 We see that Julia is looking for `Models.a`, i.e. a variable `a` defined inside the `Models` module.
 
-To fix this problem, we must write a "hygienic" macro, by
+To fix this problem, we must write an "unhygienic" macro, by
 "escaping" the code, using the `esc` function. This is a mechanism telling the compiler to look for variable definitions in the scope from which the macro is called (here, the current module `Main`), rather than the scope where the macro is defined (here, the `Models` module):
 
 


### PR DESCRIPTION
Escaping the code prevents the hygiene mechanism from introducing doing its work, thereby letting you capture variables from the call site – no?