### PR TITLE
Remove outdated link to 0.6 prerelease PPC binaries

### DIFF
--- a/downloads/index.md
+++ b/downloads/index.md
@@ -36,8 +36,7 @@ JuliaBox, all of these plotting packages are pre-installed.
 </tr>
 <tr>
     <th> Linux builds for other architectures </th>
-    <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/arm/0.6/julia-0.6.0-linux-arm.tar.gz">ARMv7 32-bit hard float</a> (<a href="https://julialang-s3.julialang.org/bin/linux/arm/0.6/julia-0.6.0-linux-arm.tar.gz.asc">GPG</a>)</td>
-    <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/ppc64le/0.6/julia-0.6.0-rc3-linux-ppc64le.tar.gz">PowerPC 64 little endian</a> (<a href="https://julialang-s3.julialang.org/bin/linux/ppc64le/0.6/julia-0.6.0-rc3-linux-ppc64le.tar.gz.asc">GPG</a>)</td>
+    <td colspan="6"> <a href="https://julialang-s3.julialang.org/bin/linux/arm/0.6/julia-0.6.0-linux-arm.tar.gz">ARMv7 32-bit hard float</a> (<a href="https://julialang-s3.julialang.org/bin/linux/arm/0.6/julia-0.6.0-linux-arm.tar.gz.asc">GPG</a>)</td>
 </tr>
 <tr>
     <th> Source </th>


### PR DESCRIPTION
The PowerPC link for 0.6 release binaries was actually RC3, since the PPC buildbot went down before the release binaries were built.