### PR TITLE
Fix title formatting

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -1,4 +1,4 @@
---
+---
 layout: default
 title:  Julia Community
 ---


### PR DESCRIPTION
For some reason, the title format was changed in 829638f04715b0e9cf5833cb2752f02dc08d3cc2, which makes the top of the community website look like – layout: default title: Julia Community —