### PR TITLE
Clean up the community page

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -7,268 +7,65 @@ All participants in the Julia community are requested to read the
 [Julia Community Standards](standards/), and abide by them in all Julia related
 forums.
 
-# Mailing Lists
+## Official Channels
 
-## Discourse
+### GitHub
+
+We use GitHub for the development of Julia itself.
+There we host our source code, track [issues](https://github.com/JuliaLang/julia/issues),
+and accept [pull requests](https://github.com/JuliaLang/julia/pulls).
+We use the issue tracker for bug reports, feature requests, and proposed changes.
+For support and questions, please use Discourse.
+
+### Discourse
 
 The primary online discussion venue for Julia is the Discourse forum at
-[discourse.julialang.org](https://discourse.julialang.org/). This is a new site which is
-to replace many of the mailing lists below. Announcements will be made on the relevant
-lists if and when they are moved.
+[discourse.julialang.org](https://discourse.julialang.org/).
+Discourse is the best place to get fast, high quality answers to Julia questions.
+In addition to Q&A, we use Discourse for announcements regarding the language, community,
+and events.
+There are a variety of categories for domain-specific questions and for package authors
+to make their own announcements.
 
-## Google groups
+Note that Discourse has taken the place of the old mailing lists, which have been made
+read-only.
 
-* [julia-news](https://groups.google.com/group/julia-news) – low traffic mailing list for important announcements, such as new releases.
-* [JuliaBox](https://groups.google.com/group/julia-box) – discussions related to running Julia in the so-called cloud.
-* [julia-users-es](https://groups.google.com/forum/#!forum/julialanges) – discussions around the usage of Julia in the Spanish language.
-* [JuliaTokyo](https://groups.google.com/forum/#!forum/julia-tokyo) – discussions around the usage of Julia in the Japanese language.
-* [Julia Users Berlin](https://groups.google.com/forum/#!forum/julia-users-berlin)
+### Slack
 
-The following lists were previously used, and are now in a read-only state for archive purposes:
+For casual conversation and quick, informal questions, we have an
+[official Julia Slack](https://julialang.slack.com).
+To join, please visit [slackinvite.julialang.org](https://slackinvite.julialang.org)
+to agree to the community code of conduct and receive an invitation.
 
-* [julia-users](https://groups.google.com/forum/#!forum/julia-users) – discussion around the usage of Julia. New users of Julia can ask their questions here. As a courtesy to others, do check the archives and documentation to see if a particular question is already answered.
-* [julia-dev](https://groups.google.com/group/julia-dev) – discussions related to the development of Julia itself. Note that this is not the primary forum for the development of Julia: most of the discussions take place on GitHub instead (see below).
-* [julia-stats](https://groups.google.com/group/julia-stats) – special purpose mailing list for discussions related to statistical programming with Julia. Topics of interest include DataFrame support, GLM modeling, and automatic generation of MCMC code for Bayesian models.
-* [julia-opt](https://groups.google.com/group/julia-opt) – discussions related to numerical optimization in Julia. This includes mathematical programming (linear, mixed-integer, conic, semi-definite, etc.), constrained and unconstrained gradient-based and gradient-free optimization, and related topics.
+## Other channels
 
-# GitHub
+Julia also has a presence on Stack Overflow under the
+[julia-lang](http://stackoverflow.com/questions/tagged/julia-lang) tag, and on Stack
+Overflow en Español under [julia](http://es.stackoverflow.com/questions/tagged/julia).
 
-We use GitHub to track our source code and for tracking and discussing [issues](https://github.com/JuliaLang/julia/issues) (bugs and their fixes, new features, and proposed changes) and [commits](https://github.com/JuliaLang/julia/commits). GitHub's pages are for Julia's development; for user support, please see the [Usage](https://discourse.julialang.org/c/user) category on Discourse.
+For those who prefer IRC to our official forums, there is a
+[#julia channel](http://webchat.freenode.net/?channels=julia) on Freenode.
+We also have an unofficial [Gitter](https://gitter.im/JuliaLang/julia) channel.
 
-There is also a list of [packages](http://pkg.julialang.org/) for Julia, many of which are also hosted on and developed using GitHub.
+## International Community
 
-Various Julia projects are hosted under the following umbrella organizations on GitHub:
+The Julia community is global, with meetups all over the world and resources in a variety
+of different languages.
 
-* [JuliaLang](https://github.com/JuliaLang) – [The language](http://www.julialang.org/)
-* [JuliaLangEs](https://github.com/JuliaLangEs) – Julia resources in the Spanish language
-* [JuliaLangPt](https://github.com/JuliaLangPt) – Site for translation of Julia documentation, etc. to Portuguese
-* [JuliaCN](https://github.com/JuliaCN) – An open-source organization for Julia localization in Chinese
-* [JuliaTokyo](https://github.com/JuliaTokyo) – Julia resources in the Japanese language
+### Localization
 
-## Computing
+Julia's official documentation is in English, but many groups work to translate and
+localize documentation and other resources.
+A few such groups that are leading these efforts include:
 
-* [JuliaArrays](https://github.com/JuliaArrays)
-* [JuliaBerry](https://github.com/JuliaBerry) – [Julia resources for the Raspberry Pi](https://juliaberry.github.io/)
-* [JuliaCI](https://github.com/JuliaCI) – Continuous Integration Support for Julia packages
-* [JuliaGPU](https://github.com/JuliaGPU) – GPU computing
-* [JuliaInterop](https://github.com/JuliaInterop) – Easy interoperability between Julia and not Julia
-* [JuliaIO](https://github.com/JuliaIO) – IO-related functionality, such as serialization
-* [JuliaParallel](https://github.com/JuliaParallel) – [Parallel programming in Julia](http://juliaparallel.github.io/)
-* [JuliaWeb](https://github.com/JuliaWeb) – Web stack
+* [JuliaTokyo](http://julia.tokyo) (Japanese)
+* [JuliaCN](https://julialang.cn) (Chinese)
+* [JuliaLangEs](https://github.com/JuliaLangEs) (Spanish)
+* [JuliaLangPt](https://github.com/JuliaLangPt) (Portuguese)
 
-## Data Science
+Please let us know if you have another organization dedicated to these efforts.
 
-* [JuliaDB](https://github.com/JuliaDB) – Various database drivers for Julia
-* [JuliaImages](https://github.com/JuliaImages) - Image Processing
-* [JuliaML](https://github.com/JuliaML) - [Machine Learning](https://juliaml.github.io/)
-* [JuliaStats](https://github.com/JuliaStats) – [Statistics](http://www.juliastats.org/)
+### Meetups
 
-## General
-
-* [JuliaDocs](https://github.com/juliadocs) – Documentation-related packages for Julia
-* [JuliaEditorSupport](https://github.com/JuliaEditorSupport) – Extensions/Plugins for text editors and IDEs
-* [Julia-i18n](https://github.com/Julia-i18n) – Internationalization (i18n) and localization (l10n) for Julians
-* [JuliaTime](https://github.com/JuliaTime) – Date and time libraries
-* [JuliaText](https://github.com/JuliaText)
-* [JuliaPraxis](https://github.com/JuliaPraxis) - Best practices
-
-## Mathematics
-
-* [JuliaDiff](https://github.com/JuliaDiff/) – [Differentiation tools](http://www.juliadiff.org/)
-* [JuliaDiffEq](https://github.com/JuliaDiffEq) – [Differential equation solving and analysis](https://juliadiffeq.github.io/)
-* [JuliaGeometry](https://github.com/JuliaGeometry) - Computational Geometry
-* [JuliaGraphs](https://github.com/JuliaGraphs) – Graph Theory and Implementation
-* [JuliaMath](https://github.com/JuliaMath) – Mathematics made easy in Julia
-* [JuliaOpt](https://github.com/JuliaOpt) – [Optimization](http://www.juliaopt.org/)
-* [JuliaPolyhedra](https://github.com/JuliaPolyhedra) – [Polyhedral computation](https://juliapolyhedra.github.io/)
-* [JuliaSparse](https://github.com/JuliaSparse) – Sparse matrix solvers
-
-## Scientific Domains
-
-* [BioJulia](https://github.com/BioJulia) – Biology
-* [EcoJulia](https://github.com/EcoJulia) – Ecology
-* [JuliaAstro](https://github.com/JuliaAstro) – Astronomy
-* [JuliaDSP](https://github.com/JuliaDSP) – Digital signal processing
-* [JuliaQuant](https://github.com/JuliaQuant) – Finance
-* [JuliaQuantum](https://github.com/JuliaQuantum) – [Julia libraries for quantum science and technology](http://juliaquantum.github.io/)
-
-## Visualization
-
-* [GiovineItalia](https://github.com/GiovineItalia) – Plotting (with [Gadfly](https://github.com/GiovineItalia/Gadfly.jl))
-* [JuliaGraphics](https://github.com/JuliaGraphics) – Drawing, Colors, GUIs
-* [JuliaPlots](https://github.com/JuliaPlots) – [Data visualization](https://juliaplots.github.io/)
-* [JuliaGL](https://github.com/JuliaGL) - OpenGL API and ecosystem
-
-# Google Summer of Code 2014
-
-Julia participated in the [Google Summer of Code 2014](http://julialang.org/gsoc/2014/).
-
-# Blogs
-
-A blog aggregator for [Julia blogs](http://www.juliabloggers.com)
-
-# YouTube
-
-Various Julia videos and playlists are posted on [YouTube](https://www.youtube.com/user/JuliaLanguage/)
-
-# Twitter
-
-* [The Julia Language](https://twitter.com/JuliaLanguage) use [#JuliaLang](https://twitter.com/hashtag/julialang?src=hash) hashtag.
-* [Julia News](https://twitter.com/julialang_news)
-* [Julia Bloggers](https://twitter.com/juliabloggers)
-* [Julia Pulse](https://twitter.com/JuliaHeartbeat)
-* [Julia StackOverflow](https://twitter.com/JuliaOverflow)
-* [JuliaComputing](https://twitter.com/JuliaComputing)
-* [Julia-i18n](https://twitter.com/julia_i18n)
-* [JuliaLangEs](https://twitter.com/JuliaLangsEs) use [#JuliaLangEs](https://twitter.com/hashtag/JuliaLangEs?src=hash) hashtag.
-* [JuliaLang Japan](https://twitter.com/JuliaLangJa) use [#JuliaTokyo](https://twitter.com/hashtag/JuliaTokyo?src=hash) hashtag.
-
-# StackOverflow
-
-* Use the [julia-lang](http://stackoverflow.com/questions/tagged/julia-lang) tag on StackOverflow, if you post a Julia related question on StackOverflow.
-* Use the [julia](http://es.stackoverflow.com/questions/tagged/julia) tag on *StackOverflow en Español*, if you post a Julia related question on StackOverflow in Spanish.
-
-# Chat Rooms
-
-## IRC
-
-* Many Julia users and developers hang out in the [#julia IRC channel](http://webchat.freenode.net/?channels=julia) on Freenode.
-
-## Gitter
-
-### Organizations
-
-* **[julia](https://gitter.im/JuliaLang/julia)** Gitter chat room is for discussions around the usage of Julia.
-* [BioJulia](https://gitter.im/BioJulia/home)
-* [IntelLabs](https://gitter.im/IntelLabs/home)
-* [julia-coverage](https://gitter.im/kshyatt/julia-coverage) Gitter chat room is for discussions around Julia tests coverage.
-* [JuliaCPH](https://gitter.im/JuliaCPH/chat) Julia Copenhagen Meetup.
-* [JuliaDiffEq](https://gitter.im/JuliaDiffEq/Lobby) Solving differential equations in Julia.
-* [JuliaDocs](https://gitter.im/juliadocs/users) Documentation-related packages for Julia.
-* [JuliaGL](https://gitter.im/JuliaGL/meta)
-* [JunoIDE](https://gitter.im/JunoLab/Juno)
-* [Julia-i18n](https://gitter.im/Julia-i18n/julia-i18n) Gitter chat room is for discussions around Julia internationalization and localization.
-* [julialang-es](https://gitter.im/JuliaLangEs/julialang-es) Gitter chat room is for discussions around the usage of Julia in the Spanish language.
-* [JuliaLangPt/julia](https://gitter.im/JuliaLangPt/julia) Gitter chat room is for discussions around the usage of Julia in the Portuguese language.
-* [JuliaML](https://gitter.im/JuliaML/chat)
-* [JuliaOpt](https://gitter.im/JuliaOpt/home)
-* [JuliaPraxis](https://gitter.im/JuliaPraxis) gitter chat rooms are for discussions around Julia best practices.
-* [JuliaQuantum](https://gitter.im/JuliaQuantum/home)
-
-### Packages
-
-* [Control.jl](https://gitter.im/jcrist/Control.jl)
-* [DataFrames.jl](https://gitter.im/JuliaLang/DataFrames.jl)
-* [Datetime.jl](https://gitter.im/quinnj/Datetime.jl)
-* [Diversity.jl](https://gitter.im/richardreeve/Diversity.jl)
-* [DSGE.jl](https://gitter.im/FRBNY-DSGE/DSGE.jl)
-* [Escher.jl](https://gitter.im/shashi/Escher.jl)
-* [Gadfly.jl](https://gitter.im/dcjones/Gadfly.jl)
-* [GLPlot.jl](https://gitter.im/SimonDanisch/GLPlot.jl)
-* [GR.jl](https://gitter.im/jheinen/GR.jl)
-* [Hypre.jl](https://gitter.im/jgoldfar/Hypre.jl)
-* [Interact.jl](https://gitter.im/JuliaLang/Interact.jl)
-* [IterativeSolvers.jl](https://gitter.im/JuliaLang/IterativeSolvers.jl)
-* [Ito.jl](https://gitter.im/aviks/Ito.jl)
-* [JavaCall.jl](https://gitter.im/aviks/JavaCall.jl)
-* [JuliaFem.jl](https://gitter.im/JuliaFEM/JuliaFEM.jl)
-* [Lazy.jl](https://gitter.im/MikeInnes/Lazy.jl)
-* [LightGraphs.jl](https://gitter.im/JuliaGraphs/LightGraphs.jl)
-* [LispSyntax.jl](https://gitter.im/swadey/LispSyntax.jl)
-* [Mathematica.jl](https://gitter.im/MikeInnes/Mathematica.jl)
-* [Phylogenetics.jl](https://gitter.im/Ward9250/Phylogenetics.jl)
-* [Plots.jl](https://gitter.im/tbreloff/Plots.jl)
-* [ROOT.jl](https://gitter.im/jpata/ROOT.jl)
-* [ValidatedNumerics.jl](https://gitter.im/dpsanders/ValidatedNumerics.jl)
-
-## QQ groups
-
-QQ is a more convenient chat service for users in China: [About QQ](http://www.imqq.com/?lang=1033)/[QQchat](http://qqchat.qq.com/). The following are some QQ groups for Julia users and developers:
-
-* Julia learners – discussions around the usage of Julia: ID 254087649
-* JuliaLang China – discussions around the development of Julia community in China: ID 188374671
-* USTC (University of Science and Technology of China) Julia User Group: ID 316628299
-* Julia Programming - Academic and industry users of Julia in China: ID 513210135
-
-To join a QQ group, search for a QQ ID in the Tencent QQ service software or app.
-
-## Slack
-
-* [JuliaTokyo](https://juliatokyo.slack.com), get your [invite](https://julia-tokyo-inviter.herokuapp.com/).
-
-## WhatsApp
-
-* JuliaLangEs, get your [invite](https://chat.whatsapp.com/invite/J9T033nZO8MLn96wWjlnHb).
-
-# Social networks
-
-## Facebook
-
-* [Julia Programming Language](https://www.facebook.com/groups/juliaproglang/) group for discussions around the usage of Julia.
-* [JuliaLangEs](https://www.facebook.com/groups/julialang.es/) group for discussions around the usage of Julia in the Spanish language.
-* [JuliaTokyo](https://www.facebook.com/groups/885166968160540/) group for discussions around the usage of Julia in the Japanese language.
-* [Julia Korea](https://www.facebook.com/groups/juliakorea/) group for discussions around the usage of Julia in the Korean language.
-* [Julia Taiwan](https://www.facebook.com/groups/JuliaTaiwan) group for discussions around the usage of Julia in the Traditional Chinese language.
-
-## VK
-
-* [Julia programming language](https://vk.com/julia_lang) group for discussions around the usage of Julia.
-
-## Meetups
-
-Julia has several [local user groups](http://julia.meetup.com):
-
-North America
-
-* [Bay Area Julia Users](http://www.meetup.com/Bay-Area-Julia-Users/)
-* [Cambridge Area Julia Users Network](http://www.meetup.com/julia-cajun/)
-* [Chicago Julia Meetup](http://www.meetup.com/JuliaChicago/)
-* [JuliaLangEs - México, D.F.](http://www.meetup.com/julialanges-mx/)
-* [León Julia Meetup](https://www.meetup.com/LeonJuliaMeetup/)
-* [NYC Julia User Group](http://www.meetup.com/NYC-Julia-User-Group/)
-* [Seattle Julia Users](http://www.meetup.com/Seattle-Julia-Users/)
-* [Southern California Julia Users](http://www.meetup.com/Southern-California-Julia-Users/)
-* [Triangle Julia Users (North Carolina)](http://www.meetup.com/Triangle-Julia-Users/)
-* [Ottawa Julia Meetup](http://www.meetup.com/Ottawa-Julia-Meetup/)
-* [Vancouver Julia Users](http://www.meetup.com/Vancouver-Julia-Users/)
-
-Europe
-
-* [London Julia Users Group](http://www.meetup.com/London-Julia-Users-Group/)
-* [Zurich Julia Users Group](http://www.meetup.com/Zurich-Julia-User-Group/)
-* [Vienna Julia Meetup](http://www.meetup.com/Vienna-Julia-Meetup/)
-* [Julia Users Berlin](https://www.meetup.com/Julia-Users-Group/), see also our [news site](http://julia-users-berlin.github.io/)
-* [Warszawskie Forum Julia](https://www.meetup.com/Warszawskie-Forum-Julia/)
-* [Barcelona Julia Meetup](https://www.meetup.com/Barcelona-Julia-Meetup/)
-
-Asia
-
-* [Bangalore Julia User Group](http://www.meetup.com/Bangalore-Julia-User-Group/)
-* [Beijing Julia User Group](https://www.meetup.com/juliacn/)
-* [JuliaDelhi](https://www.meetup.com/Juliadelhi/)
-* [Julia Taiwan](https://juliataiwan.kktix.cc/)
-* [Singapore Julia User Group](https://www.meetup.com/Singapore-Julia-User-Group/)
-
-Australia
-
-* [Sydney Julia User Group](https://www.meetup.com/Sydney-Julia-Julialang-Meetup/)
-
-South America
-
-* [São Paulo Julia Meetup](https://www.meetup.com/pt-BR/Julia-Sao-Paulo/)
-* [Rio de Janeiro Julia Meetup](https://www.meetup.com/pt-BR/Julia-Rio-de-Janeiro/)
-
-Don't have one in your area? Why not start one!
-
-## Connpass
-
-Asia
-
-* [Julia Tokyo](https://juliatokyo.connpass.com/)
-
-
-# Reddit
-
-[The Julia Language SubReddit](http://www.reddit.com/r/Julia/) is a collection of various blog posts and articles related to Julia.
-
-Don't see your community resources listed here? Please submit a [pull request](https://github.com/JuliaLang/julialang.github.com/edit/master/community/index.md) so we can share them!
+Julia has local user groups in Europe, North and South America, Asia, and Australia.
+Find one near you or start a new one at [julia.meetup.com](http://julia.meetup.com).


### PR DESCRIPTION
The Git diff is really confusing; I recommend just looking at the rendered page.

This cleans up the community page by making our official channels more explicit and by removing a lot of package-specific information.

If you're wondering why I chose `##` and `###` markdown header levels, clone and build this branch then look at the rendered page; IMO it looks much, much nicer this way, otherwise the headers are enormous.