### PR TITLE
Add extra info on Julia support to the community page

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -3,44 +3,59 @@ layout: default
 title:  Julia Community
 ---
 
-All participants in the Julia community are requested to read the
-[Julia Community Standards](standards/), and abide by them in all Julia related
-forums.
+Please take a moment to read the [Julia Community Standards](standards/). We
+expect that your participation in any Julia related forum, online or offline,
+respects these standards.
 
 ## Official Channels
 
 ### GitHub
 
-We use GitHub for the development of Julia itself.
-There we host our source code, track [issues](https://github.com/JuliaLang/julia/issues),
-and accept [pull requests](https://github.com/JuliaLang/julia/pulls).
-We use the issue tracker for bug reports, feature requests, and proposed changes.
-For support and questions, please use Discourse.
+We use GitHub for the development of Julia itself. There we host our source
+code, track [issues](https://github.com/JuliaLang/julia/issues), and accept
+[pull requests](https://github.com/JuliaLang/julia/pulls). We use the issue
+tracker for bug reports, feature requests, and proposed changes. For support and
+questions, please use Discourse.
 
 ### Discourse
 
-The primary online discussion venue for Julia is the Discourse forum at
-[discourse.julialang.org](https://discourse.julialang.org/).
-Discourse is the best place to get fast, high quality answers to Julia questions.
-In addition to Q&A, we use Discourse for announcements regarding the language, community,
-and events.
-There are a variety of categories for domain-specific questions and for package authors
-to make their own announcements.
+The primary online discussion venue for Julia is the [Discourse
+forum](https://discourse.julialang.org/). Discourse is the right place to do any
+of the following:
+- **Keep up to date** on important Julia announcements like language releases
+  and JuliaCon.
+- **Ask a question** about any aspect of using or developing Julia or its
+  associated packages and tools. The Discourse forum is the best place to get a
+  fast, high-quality answer to your Julia question. There are subcategories for
+  various Julia application domains such as machine learning, finance,
+  visualisation and GPUs. Questions from newcomers are always welcome: you can
+  use the "first steps" tag to highlight your question as one that would benefit
+  other new users.
+- **Respond to others' questions**: our community thrives when people share
+  their knowledge and experience.
+- **Announce a new package** or solicit feedback about something you have been
+  developing.
+- **Advertise** Julia-related jobs and community events.
 
-Note that Discourse has taken the place of the old mailing lists, which have been made
-read-only.
+The Discourse forum replaced the Julia mailing lists, the largest of which were
+[julia-users](https://groups.google.com/forum/#!forum/julia-users) and
+[julia-dev](https://groups.google.com/forum/#!forum/julia-dev), at the end
+of 2016. Those lists are now read-only but you may like to search them to see if
+your question has already been raised.
 
 ### Slack
 
-For casual conversation and quick, informal questions, we have an
-[official Julia Slack](https://julialang.slack.com).
-To join, please visit [slackinvite.julialang.org](https://slackinvite.julialang.org)
-to agree to the community code of conduct and receive an invitation.
+For casual conversation and quick, informal questions, we have an [official
+Julia Slack](https://julialang.slack.com). Slack is also a good place to start
+if you think you need help but aren't quite sure what you should be asking or
+where to ask it. To join, please visit
+[slackinvite.julialang.org](https://slackinvite.julialang.org/) to agree to the
+community code of conduct and receive an invitation.
 
 ### YouTube
 
-All the [JuliaCon](http://juliacon.org) videos and other videos of
-general interest in the community are uploaded to the [Julia Language YouTube
+All the [JuliaCon](http://juliacon.org) videos and other videos of general
+interest in the community are uploaded to the [Julia Language YouTube
 channel](https://www.youtube.com/user/JuliaLanguage).
 
 
@@ -50,23 +65,28 @@ On Twitter, tweet with the
 [#julialang](https://twitter.com/search?q=%23julialang) hashtag.
 
 Julia also has a presence on Stack Overflow under the
-[julia-lang](http://stackoverflow.com/questions/tagged/julia-lang) tag, and on Stack
-Overflow en Español under [julia](http://es.stackoverflow.com/questions/tagged/julia).
+[julia-lang](http://stackoverflow.com/questions/tagged/julia-lang) tag, and on
+Stack Overflow en Español under
+[julia](http://es.stackoverflow.com/questions/tagged/julia).
 
-For those who prefer IRC to our official forums, there is a
-[#julia channel](http://webchat.freenode.net/?channels=julia) on Freenode.
-We also have an unofficial [Gitter](https://gitter.im/JuliaLang/julia) channel.
+For those who prefer IRC to our official forums, there is a [#julia
+channel](http://webchat.freenode.net/?channels=julia) on Freenode. We also have
+an unofficial [Gitter](https://gitter.im/JuliaLang/julia) channel.
+
+There is a small [Julia subreddit](https://www.reddit.com/r/Julia/) for casual
+discussion.
+
 
 ## International Community
 
-The Julia community is global, with meetups all over the world and resources in a variety
-of different languages.
+The Julia community is global, with meetups all over the world and resources in
+a variety of different languages.
 
 ### Localization
 
-Julia's official documentation is in English, but many groups work to translate and
-localize documentation and other resources.
-A few such groups that are leading these efforts include:
+Julia's official documentation is in English, but many groups work to translate
+and localize documentation and other resources. A few such groups that are
+leading these efforts include:
 
 * [JuliaTokyo](http://julia.tokyo) (Japanese)
 * [JuliaCN](https://julialang.cn) (Chinese)
@@ -77,5 +97,6 @@ Please let us know if you have another organization dedicated to these efforts.
 
 ### Meetups
 
-Julia has local user groups in Europe, North and South America, Asia, and Australia.
-Find one near you or start a new one at [julia.meetup.com](http://julia.meetup.com).
+Julia has local user groups in Europe, North and South America, Asia, and
+Australia. Find one near you or start a new one at
+[julia.meetup.com](http://julia.meetup.com).


### PR DESCRIPTION
Some extra info on how to get support for Julia was added to the Julia repo as part of https://github.com/JuliaLang/julia/pull/24052, but we decided that it would be more appropriate to put it here. I've therefore filled out the Community page slightly with content from that PR. The page now has more description of what you might use each channel for. It also highlights that newcomers are welcome on Discourse.