### PR TITLE
Prune GSoC

### DIFF
--- a/soc/projects/diffeq.md
+++ b/soc/projects/diffeq.md
@@ -7,62 +7,26 @@ title:  DiffEq Projects – Summer of Code
 
 {% include toc.html %}
 
-## Efficient DiffEq-Specific Differentiation Tooling
+## Stiffness Detection and Automatic Switching Algorithms
 
-Methods for solving stiff differential equations and differential algebraic
-equations (DAEs) are composed of similar calculus objects: gradients, Jacobians,
-etc.  However, not only are these objects common, but there are also very common
-use patterns. For example, the quantity (M - gamma*J)^(-1), (where M is a mass
-matrix, J is the Jacobian, and gamma is a constant), is found in Rosenbrock
-methods, Newton solvers for implicit Runge-Kutta methods, and update equations
-for implicit multistep methods.
+Stiffness is a phenomena in differential equations which requires implicit methods
+in order to be efficiently solved. However, implicit methods are inherently
+more costly and thus inefficient when they are not needed. This is an issue
+because many problems are not always stiff, and instead switch from stiff
+and nonstiff modes. The purpose of this project would be to develop functionality
+for detecting stiffness during integration and testing algorithms for automatic
+switching between appropriate algorithms. These would not only be more efficient
+on a large class of problems, but also decrease the cognative burden on the
+user by being efficient for a large class of algorithms and likely become the
+new default methods.
 
-However, to make these efficient and cover a large array of problems we will
-need to develop new tools for calculating such Jacobians. In many cases, like
-discretizations of PDEs, the user may know in advance that the Jacobian has a
-banded or sparse structure and can provide such a structure. In these cases,
-the calculation can be made much more efficient by using this information to
-calculate a low fewer function calls. Additionally, none of the current
-differentiation tools in Julia support complex numbers, which limits the
-applicability of stiff solvers to PDEs from quantum mechanics like Schrodinger's
-equation.
+**Recommended Skills**: Background knowledge in numerical methods for solving
+differential equations. The student is expected to already be familiar with
+the concept of stiffness in ODEs, but not necessarily an expert.
 
-Students who take on this project will encounter and utilize many of the core tools for scientific computing in Julia, and the result will be a very useful library for all differential equation solvers.
-
-**Recommended Skills**: Familiarity with multivariable calculus (Jacobians).
-
-**Expected Results**: A high-performance backend library for native differential
-equation solvers.
-
-**Mentors**: [Chris Rackauckas](https://github.com/ChrisRackauckas)
-
-## Natural syntax parsing and symbolic transformations of differential equations
-
-[ParameterizedFunctions.jl](https://github.com/JuliaDiffEq/ParameterizedFunctions.jl)
-is a component of the JuliaDiffEq ecosystem that allows for users to define differential
-equations in a natural syntax (with parameters). The benefits of this setup are threefold:
-
-- The existence of parameters allows for optimization / machine learning techniques
-  to be applied to and learn parameters from data.
-- The natural syntax allows [DifferentialEquations.jl Online](http://app.juliadiffeq.org/)
-  to have a user-friendly programming-free frontend.
-- The setup allows for [SymEngine.jl](https://github.com/symengine/SymEngine.jl)
-  to symbolically calculate various mathematical objects to speed up the solvers.
-
-However, the macros are currently only able to parse ordinary differential
-equations (ODEs) and stochastic differential equations (SDEs). An extension to
-the language and parser will need to be introduced in order to handle
-differential algebraic equations (DAEs) and delay differential equations (DDEs).
-In addition, symbolic enhancements could be applied to automatically lower the
-index of the DAEs and transform delay equations into larger systems of ODEs,
-greatly increasing the amount of equations which can be easily solved. Finally,
-this improved parser can be used to develop new pages for DifferentialEquations.jl
-Online for solving DAEs and DDEs.
-
-**Recommended Skills**: Some previous knowledge of parsing.
-
-**Expected Results**: An improved parser within the macro which supports delay
-and algebraic differential equations.
+**Expected Results**: Implementation of a trait-based engine for
+algorithm-specific stiffness metrics, and implementations of new algorithms
+for switching strategies.
 
 **Mentors**: [Chris Rackauckas](https://github.com/ChrisRackauckas)
 
@@ -82,14 +46,14 @@ methods. Possible families of methods to implement are:
 **Recommended Skills**: Background knowledge in numerical analysis, numerical
 linear algebra, and the ability to write fast code.
 
-**Expected Results**: A production-quality ODE/DAE solver package.
+**Expected Results**: Contributions of production-quality ODE/DAE solver methods.
 
 **Mentors**: [Chris Rackauckas](https://github.com/ChrisRackauckas)
 
 ## Tools for global and adjoint sensitivity analysis
 
 Global Sensitivity Analysis is a popular tool to assess the affect that parameters
-have on a differential equation model. Global Sensitivity Analysis tools can be
+have on a differential equation model. A good introduction [can be found in this thesis](http://discovery.ucl.ac.uk/19896/). Global Sensitivity Analysis tools can be
 much more efficient than Local Sensitivity Analysis tools, and give a better
 view of how parameters affect the model in a more general sense. Julia currently
 has an implementation Local Sensitivity Analysis, but there is no method for Global
@@ -101,7 +65,8 @@ In addition, adjoint sensitivity analysis is a more efficient method than
 standard local sensitivity analysis when the number of parameters is large.
 It is the differential equations extension of "backpropagation" and is used
 in many other domains like parameter estimation as part of the optimization
-process.
+process. An introduction to the adjoint sensitivity equations
+[can be found in this documentation](https://computation.llnl.gov/casc/nsde/pubs/cvs_guide.pdf).
 
 **Recommended Skills**: An understanding of how to use DifferentialEquations.jl
 to solve equations.
@@ -111,78 +76,32 @@ sensitivity analysis.
 
 **Mentors**: [Chris Rackauckas](https://github.com/ChrisRackauckas)
 
-## Machine learning tools for classification of qualitative traits of differential equation solutions
-
-Machine learning has become a popular tool for understanding data, but scientists
-typically want to use this data to better understand their differential
-equation-based models. Differential equations usually have parameters which are
-unknown but when changed can cause qualitative differences to the results. By
-pairing machine learning tooling with data generation from differential equation
-models, tools can be developed which can classify when behaviors are to be
-expected in the solution.
-
-**Recommended Skills**: Background knowledge of standard machine learning
-techniques and the usage of DifferentialEquations.jl
-
-**Expected Results**: Tools for easily classifying parameters using machine
-learning tooling for users inexperienced with machine learning.
-
-**Mentors**: [Chris Rackauckas](https://github.com/ChrisRackauckas)
-
 ## Discretizations of partial differential equations
 
-One of the major uses for differential equations solvers is for partial
-differential equations (PDEs). PDEs are solved by discretizing to create ODEs
-which are then solved using ODE solvers. However, in many cases a good
-understanding of the PDEs are required to perform this discretization and
-minimize the error. The purpose of this project is to produce a library with
-common PDE discretizations to make it easier for users to solve common PDEs.
+There are two ways to approach libraires for partial differential equations (PDEs):
+one can build "toolkits" which enable users to discretize any PDE but require knowledge
+of numerical PDE methods, or one can build "full-stop" PDE solvers for specific
+PDEs. There are many different ways solving PDEs could be approached, and here
+are some ideas for potential projects:
 
-The core of this project will be to build tooling that can be used to make it
-easy to discretize any partial differential equation in an efficient manner.
-This will be used to build a finite difference solver for the Heat Equation, a
-canonical problem in many fields, which can be profiled and benchmarked to
-ensure speed and accuracy. From there, the student can use these tools to take
-other canoncial partial differential equations, doing things such as:
-
-1) Discretizations of fluid dynamical equations, such as diffusion-advection-
-   convection equations.
-2) Extensions of discretizations to stochastic (random) partial differential
-   equations.
-3) Tackling more efficiency issues: full utilization of operator linearity,
-   split operator and IMEX (implicit-explicit) discretizations.
-4) Discretizations of hyperbolic PDEs such as the Hamilton-Jacobi-Bellman
-  equations.
-5) Using stochastic differential equation (SDE) solvers to efficiently (and
+1) Enhancement of existing tools for discretizing PDEs. The finite differencing
+   (FDM) library [DiffEqOperators.jl](https://github.com/JuliaDiffEq/DiffEqOperators.jl)
+   could be enahnced to allow non-uniform grids or composition of operators. The
+   finite element method (FEM) library [FEniCS.jl](https://github.com/JuliaDiffEq/FEniCS.jl)
+   could wrap more of the FEniCS library.
+2) Full stop solvers of common fluid dynamical equations, such as diffusion-advection-
+   convection equations, or of hyperbolic PDEs such as the Hamilton-Jacobi-Bellman
+   equations would be useful to many users.
+3) Using stochastic differential equation (SDE) solvers to efficiently (and
    highly parallel) approximate certain PDEs.
+4) Development of ODE solvers for more efficiently solving specific types of
+   PDE discretizations. See the "Native Julia solvers for ordinary differential
+   equations" project.
 
 **Recommended Skills**: Background knowledge in numerical methods for solving
 differential equations. Some basic knowledge of PDEs, but mostly a willingness
 to learn and a strong understanding of calculus and linear algebra.
 
 **Expected Results**: A production-quality PDE solver package for some common PDEs.
-
-**Mentors**: [Chris Rackauckas](https://github.com/ChrisRackauckas)
-
-## Stiffness Detection and Automatic Switching Algorithms
-
-Stiffness is a phenomena in differential equations which requires implicit methods
-in order to be efficiently solved. However, implicit methods are inherently
-more costly and thus inefficient when they are not needed. This is an issue
-because many problems are not always stiff, and instead switch from stiff
-and nonstiff modes. The purpose of this project would be to develop functionality
-for detecting stiffness during integration and testing algorithms for automatic
-switching between appropriate algorithms. These would not only be more efficient
-on a large class of problems, but also decrease the cognative burden on the
-user by being efficient for a large class of algorithms and likely become the
-new default methods.
-
-**Recommended Skills**: Background knowledge in numerical methods for solving
-differential equations. The student is expected to already be familiar with
-the concept of stiffness in ODEs, but not necessarily an expert.
-
-**Expected Results**: Implementation of a trait-based engine for
-algorithm-specific stiffness metrics, and new algorithms which implement
-specific switching strategies.
 
 **Mentors**: [Chris Rackauckas](https://github.com/ChrisRackauckas)

--- a/soc/projects/hpc.md
+++ b/soc/projects/hpc.md
@@ -9,12 +9,6 @@ Julia is emerging as a serious tool for technical computing and is ideally suite
 
 {% include toc.html %}
 
-## Fixed-size arrays with SIMD support
-
-Julia uses OpenBLAS for matrix algebra, but OpenBLAS is better suited for large matrices. For operations with small matrices and vectors, one can often obtain substantial speedups by implementing everything in Julia. At least two candidate implementations [already](https://github.com/twadleigh/ImmutableArrays.jl) [exist](https://github.com/JuliaLang/julia/issues/5857), with the first more thoroughly developed but the second (currently just a sketch) having some features that are attractive for inclusion in `Base`.
-
-The project would be to flesh out operations with fixed-size arrays, and get them interoperating seamlessly with other types. It would be desirable implement operations for certain sizes using Julia's up-and-coming [SIMD support](https://github.com/JuliaLang/julia/pull/5355).
-
 ## Parallel graph development
 
 The [LightGraphs.jl](https://github.com/JuliaGraphs/LightGraphs.jl) package provides a fast, robust set of graph analysis tools. This project would implement additions to LightGraphs to support parallel computation for a subset of graph algorithms. Examples of algorithms that would benefit from adaptation to parallelism would include centrality measures and traversals.
@@ -22,14 +16,6 @@ The [LightGraphs.jl](https://github.com/JuliaGraphs/LightGraphs.jl) package prov
 **Expected Results**: creation of LightGraphs-based data structures and algorithms that take advantage of large-scale parallel computing environments.
 
 **Mentorship Inquiries**: Drop by [LightGraphs.jl on Gitter](https://gitter.im/JuliaGraphs/LightGraphs.jl).
-
-## Ensure that Julia runs smoothly on current large HPC systems
-
-Julia employs several techniques that are novel in the field of high performance computing, such as just-in-time compiling, or first-class support of an interactive environment, or dynamically adding/removing worker processes. This clashes with the traditional ahead-of-time compiled programes running in batch mode. However, the advantages of Julia's approach are clear. This project explores how "typical" Julia programs can be run efficiently on current large scale systems such as, e.g. [Blue Waters](https://bluewaters.ncsa.illinois.edu) or [Cori](http://www.nersc.gov/users/computational-systems/cori/).
-
-**Expected Results**: Run a large, parallel Julia application on a high-end HPC system
-
-**Knowledge Prerequisites**: High-performance computing, MPI
 
 ## Simple persistent distributed storage
 
@@ -40,3 +26,21 @@ This project proposes to implement a very simple persistent storage mechanism fo
 Distributed computation frameworks like Hadoop/MapReduce have demonstrated the usefulness of an abstraction layer that takes care of low level concurrency concerns such as atomicity and fine-grained synchronization, thus allowing users to concentrate on task-level decomposition of extremely large problems such as massively distributed text processing. However, the tree-based scatter/gather design of MapReduce limits its usefulness for general purpose data parallelism, and in particular poses significant restrictions on the implementation of iterative algorithms.
 
 This project proposal is to implement a native Julia framework for distributed execution for general purpose data parallelism, using dynamic, runtime-generated general task graphs which are flexible enough to describe multiple classes of parallel algorithms. Students will be expected to weave together native Julia parallelism constructs such as the `ClusterManager` for massively parallel execution, and automate the handling of data dependencies using native Julia `RemoteRefs` as remote data futures and handles. Students will also be encouraged to experiment with novel scheduling algorithms.
+
+## GPUArrays
+
+### Integration with existing GPU libraries
+
+In GPUArrays we don't want to reinvent the wheel and leverage the great power of CU/CL - BLAS ( or even CU/CL - FFT).
+Fortunately, Julia's abstract array interface makes it fairly straightforward to integrate these libraries in a natural way, since Julia already has OpenBLAS deeply integrated in the base array abstraction.
+We have a basic strategy laid out for the integration and can mentor someone who is willing to write the it!
+
+### JIT compiling GPU Code
+
+GPUArrays heavily relies on just in time compilation of high performance kernels on the arrays.
+The foundation for this is already part of GPUArrays in form of a basic map/reduce/broadcast implementation, using a Transpiler and CUDAnative.
+What we now need is a lot of tests, improvements to the compiler/transpiler, benchmarks and fine tuning the performance of our kernels.
+Someone who is more experienced in writing GPU kernels is also welcome to enrich GPUArrays with the implementation of more advanced kernels, e.g.
+tiled iterations, filtering primitives, moving windows, etc.
+
+**Mentors**: Simon Danisch

--- a/soc/projects/images.md
+++ b/soc/projects/images.md
@@ -28,13 +28,3 @@ OpenCV is one of the pre-eminent image-processing frameworks, and there is an ex
 **Expected Results:** A rejuvinated OpenCV package that integrates more effectively into the ecosystem of JuliaImages.
 
 **Mentors:** [Maximiliano Suster](https://github.com/maxruby) and [Tim Holy](https://github.com/timholy/).
-
-## Image segmentation
-
-Image segmentation is the process of dividing an image up into constituent objects. While imperfect, a number of well-tested [algorithms](https://en.wikipedia.org/wiki/Image_segmentation) have been developed for this task. This project would implement a number of these algorithms in pure Julia, building on existing packages and the framework in JuliaImages. This project would also develop a number of tutorials/demonstrations illustrating the methods.
-
-**Recommended skills:** Strong mathematical background and the ability to read primary literature.
-
-**Expected Results:** Implementation of additional algorithms for segmentation. Some contributions would be to existing or new packages in JuliaImages, others might leverage work in the wider Julia ecosystem. Documentation and tutorials would be hosted at the main JuliaImages site.
-
-**Mentors:** [Anchit Navelkar](https://github.com/mronian) and [Tim Holy](https://github.com/timholy/).

--- a/soc/projects/ml.md
+++ b/soc/projects/ml.md
@@ -35,24 +35,6 @@ It would be useful to load existing trained models created with other frameworks
 
 **Mentors**: Mike Innes
 
-## GPUArrays
-
-### Integration with existing GPU libraries
-
-In GPUArrays we don't want to reinvent the wheel and leverage the great power of CU/CL - BLAS ( or even CU/CL - FFT).
-Fortunately, Julia's abstract array interface makes it fairly straightforward to integrate these libraries in a natural way, since Julia already has OpenBLAS deeply integrated in the base array abstraction.
-We have a basic strategy laid out for the integration and can mentor someone who is willing to write the it!
-
-### JIT compiling GPU Code
-
-GPUArrays heavily relies on just in time compilation of high performance kernels on the arrays. 
-The foundation for this is already part of GPUArrays in form of a basic map/reduce/broadcast implementation, using a Transpiler and CUDAnative.
-What we now need is a lot of tests, improvements to the compiler/transpiler, benchmarks and fine tuning the performance of our kernels.
-Someone who is more experienced in writing GPU kernels is also welcome to enrich GPUArrays with the implementation of more advanced kernels, e.g.
-tiled iterations, filtering primitives, moving windows, etc.
-
-**Mentors**: Simon Danisch
-
 ## Standardized dataset packaging
 
 Scientific and technical computing often makes use of publicly available datasets. Often, there's a lot of overhead to finding these data sets and coercing them into a usable format. Packages like [RDatasets.jl](https://github.com/johnmyleswhite/RDatasets.jl/) and [MNIST.jl](https://github.com/johnmyleswhite/MNIST.jl) attempt to make this easier by downloading data automatically and providing it as a Julia data structure.
@@ -64,3 +46,22 @@ This project involves building a "[BinDeps.jl](https://github.com/JuliaLang/BinD
 **Recommended Skills**: Only standard programming skills are needed for this project. Familiarity with Julia is a plus.
 
 **Mentors**: [JuliaML Members](https://github.com/orgs/JuliaML/people)
+
+## Machine learning tools for classification of qualitative traits of differential equation models
+
+Machine learning has become a popular tool for understanding data, but scientists
+typically want to use this data to better understand their differential
+equation-based models. Differential equations usually have parameters which are
+unknown but when changed can cause qualitative differences to the results. By
+pairing machine learning tooling with data generation from differential equation
+models, tools can be developed which can classify when behaviors are to be
+expected in the solution.
+
+**Recommended Skills**: Background knowledge of standard machine learning
+techniques. It's recommended but not required that one has basic knowledge of
+differential equations and DifferentialEquations.jl.
+
+**Expected Results**: Tools for easily classifying parameters using machine
+learning tooling for users inexperienced with machine learning.
+
+**Mentors**: [Chris Rackauckas](https://github.com/ChrisRackauckas)

--- a/soc/projects/ml.md
+++ b/soc/projects/ml.md
@@ -5,26 +5,6 @@ title: Machine Learning General Projects – Summer of Code
 
 {% include toc.html %}
 
-## Torch.jl
-
-The [Torch](https://github.com/torch/torch7) library provides a fast implementation of N-dimensional arrays which can run on the CPU or GPU. This has been used to build popular machine learning libraries in Lua (torch itself) and Python (via [PyTorch](http://pytorch.org/)). Wrapping Torch in Julia would be a great way to get general GPU acceleration of Julia code, and could also be integrated with higher-level Julia ML libraries like Knet, ReverseDiff and Flux.
-
-**Expected Results**: A Julia package wrapping the Torch C library.
-
-**Recommended Skills**: Knowledge of Julia's C FFI and calling C code.
-
-**Mentors**: Mike Innes, Pontus Stenetorp
-
-## Data loading and training processes for Flux.jl
-
-Currently [Flux](https://github.com/MikeInnes/Flux.jl) best supports a basic (stochastic) gradient descent training process. This project would involve implementing other optimisers like ADAM in the library, as well as extending the training processes to carry out user-configurable analysis or reporting during training.
-
-**Expected Results**: New optimisers for the Flux library.
-
-**Recommended Skills**: Familiarity with neural networks.
-
-**Mentors**: Mike Innes
-
 ## Model Loading for Flux.jl
 
 It would be useful to load existing trained models created with other frameworks – say Caffe, TensorFlow or MXNet – into Flux. This project would involve investigating the model formats and building readers so that those models can be run in native Julia.

--- a/soc/projects/numerics.md
+++ b/soc/projects/numerics.md
@@ -21,16 +21,6 @@ Iterative methods for solving numerical linear algebraic problems are crucial fo
 
 **Mentors:** [Jiahao Chen](https://jiahao.github.io/)
 
-## Native usage of LinearMaps in iterative solvers
-
-While one normally thinks of solving the linear equation Ax=b with A being a matrix, this concept is more generally applied to A being a linear map. In many domains of science, this idea of directly using a linear map instead of a matrix allows for one to solve the equation in a more efficient manner. Iterative methods for linear solving only require the ability compute `A*x` in order solve the system, and thus these methods can be extended to use more general linear maps. By restructuring IterativeSolvers.jl to use `LinearMap` types from [LinearMaps.jl](https://github.com/Jutho/LinearMaps.jl), these applications can be directly supported in the library.
-
-**Recommended Skills**: Strong linear algebra background. Familiarity with numerical linear algebra.
-
-**Expected Results**: The ability to use more general LinearMaps in the IterativeSolvers.jl methods.
-
-**Mentors:** [Jiahao Chen](https://jiahao.github.io/)
-
 ## PETSc integration for scalable technical computing
 
 [PETSc](http://www.mcs.anl.gov/petsc) is a widely used framework of data structures and computational routines suitable for massively scaling scientific computations. Many of these algorithms are also ideally suited for big data applications such as computing principal components of very large sparse matrices and solving complicated forecasting models with distributed methods for solving partial differential equations.

--- a/soc/projects/tooling.md
+++ b/soc/projects/tooling.md
@@ -11,7 +11,7 @@ title:  Tooling Projects – Summer of Code
 
 The [Juno](http://junolab.org) is open to general project ideas (from here or not); feel free to get in contact via the [forum](http://discourse.julialang.org/) to discuss!
 
-## Progress Metre Improvements
+## Progress Meter Improvements
 
 Right now Juno's progress metre works well but is fairly basic. In particular, it could be improved by:
 
@@ -27,18 +27,6 @@ These issues prevent package authors from using `@progress` over loops without m
 **Recommended Skills**: Some experience with Julia and Juno is good, but only general programming skills are required.
 
 **Mentors**: [Mike Innes](https://github.com/mikeinnes)
-
-## Documentation search & navigation
-
-We'd like to make finding and viewing relevant documentation a core part of the Juno/Julia experience. As well as viewing docs for a particular function, it'd be great to take advantage of the extensive Markdown docs provided by packages for other purposes. For example, a basic doc search engine could allow users to find relevant functionality even when they don't know the names of the functions involved. (This could even be extended to searching across all packages!)
-
-Initially this project could be built as a package or as an extension to the Atom.jl package. Eventually, we'd also like to integrate the functionality with a nice UI inside of Juno, and this could serve as extension work for an enterprising student.
-
-**Expected Results**: Tools in Julia for collating and working with package documentation, as well as a plan for how this can become part of the IDE or other tooling.
-
-**Recommended Skills**: The Julia-side parts of this could be done by anyone with programming experience. For Juno integration, familiarity with javascript or Atom development is a big plus.
-
-**Mentors**: [Mike Innes](https://github.com/mikeinnes), [Michael Hatherly](https://github.com/michaelhatherly)
 
 ## Package installation UI
 


### PR DESCRIPTION
Get rid of completed GSoC projects to clear up space and make it easier to find what's available. 

@timholy do you agree with taking image segmentation off?
@MikeInnes are there any of the Flux.jl projects to remove?