### PR TITLE
Move all macOS download URLs to new location

### DIFF
--- a/downloads/index.md
+++ b/downloads/index.md
@@ -27,7 +27,7 @@ JuliaBox, all of these plotting packages are pre-installed.
 </tr>
 <tr>
     <th> macOS Package (.dmg) <a href="platform.html#macos">[help]</a></th>
-    <td colspan="6"> <a href="https://julialang-s3.julialang.org/bin/osx/x64/0.6/julia-0.6.1-osx10.7+.dmg">10.8+ 64-bit</a> </td>
+    <td colspan="6"> <a href="https://julialang-s3.julialang.org/bin/mac/x64/0.6/julia-0.6.1-mac64.dmg">10.8+ 64-bit</a> </td>
 </tr>
 <tr>
     <th> Generic Linux Binaries for x86 <a href="platform.html#generic-linux-binaries">[help]</a></th>

--- a/downloads/oldreleases.md
+++ b/downloads/oldreleases.md
@@ -149,13 +149,13 @@ anymore.
 <table class="downloads"><tbody>
 <tr>
     <th> Windows Archive (.zip) </th>
-    <td> <a href="https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/julialang/julia0.1.2-WINNT-i686+Git.zip">32-bit</a> </td>
+    <td> <a href="http://julialang-s3.julialang.org/bin/winnt/x86/0.1/julia0.1.2-WINNT-i686+Git.zip">32-bit</a> </td>
     <td> 64-bit (Unavailable) </td>
 </tr>
 <tr>
     <th> macOS Package (.dmg) </th>
     <td>32-bit (Unavailable)</td>
-    <td> <a href="https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/julialang/Julia-0.1.2.dmg">64-bit</a> </td>
+    <td> <a href="https://julialang-s3.julialang.org/bin/mac/x64/0.1/julia-0.1.2-mac64.dmg">64-bit</a> </td>
 </tr>
 <tr>
     <th> Source </th>

--- a/downloads/oldreleases.md
+++ b/downloads/oldreleases.md
@@ -18,7 +18,7 @@ anymore.
 </tr>
 <tr>
     <th> macOS Package (.dmg) </th>
-    <td colspan="6"> <a href="https://julialang-s3.julialang.org/bin/osx/x64/0.5/julia-0.5.2-osx10.7+.dmg">10.8+ 64-bit</a> </td>
+    <td colspan="6"> <a href="https://julialang-s3.julialang.org/bin/mac/x64/0.5/julia-0.5.2-mac64.dmg">10.8+ 64-bit</a> </td>
 </tr>
 <tr>
     <th> Generic Linux binaries </th>
@@ -49,7 +49,7 @@ anymore.
 </tr>
 <tr>
     <th> macOS Package (.dmg) </th>
-    <td colspan="6"> <a href="https://julialang-s3.julialang.org/bin/osx/x64/0.4/julia-0.4.7-osx10.7+.dmg">10.7+ 64-bit</a> </td>
+    <td colspan="6"> <a href="https://julialang-s3.julialang.org/bin/mac/x64/0.4/julia-0.4.7-mac64.dmg">10.7+ 64-bit</a> </td>
 </tr>
 <tr>
     <th> Generic Linux binaries </th>
@@ -79,7 +79,7 @@ anymore.
 </tr>
 <tr>
     <th> macOS Package (.dmg) </th>
-    <td colspan="2"> <a href="https://julialang-s3.julialang.org/bin/osx/x64/0.3/julia-0.3.12-osx10.7+.dmg">10.7+ 64-bit</a> </td>
+    <td colspan="2"> <a href="https://julialang-s3.julialang.org/bin/mac/x64/0.3/julia-0.3.12-mac64.dmg">10.7+ 64-bit</a> </td>
 </tr>
 <tr>
     <th> Ubuntu packages (.deb) </th>
@@ -131,8 +131,7 @@ anymore.
 </tr>
 <tr>
     <th> macOS Package (.dmg) </th>
-    <td> <a href="https://julialang-s3.julialang.org/bin/osx/x64/0.2/julia-0.2.1-osx10.6.dmg">10.6 64-bit</a> </td>
-    <td> <a href="https://julialang-s3.julialang.org/bin/osx/x64/0.2/julia-0.2.1-osx10.7+.dmg">10.7+ 64-bit</a> </td>
+    <td> <a href="https://julialang-s3.julialang.org/bin/mac/x64/0.2/julia-0.2.1-mac64.dmg">10.7+ 64-bit</a> </td>
 </tr>
 <tr>
     <th> Ubuntu packages (.deb) </th>


### PR DESCRIPTION
As part of the process of normalizing the structure of the URLs on AWS, we're renaming `osx` to `mac` everywhere, and replacing `osx10.x+` in the file names to `mac64`. **All links to the old URLs will still work; the files in the `mac` tree are copies of those in the `osx` tree, which still exists.**

Note that with this new naming scheme, OS X 10.6 and 10.7+ are no longer distinguishable in a consistent manner. Because of that, and because both OS X 10.6 and Julia 0.2 are _way_ past EOL, the link for Julia 0.2 on OS X 10.6 has been removed. The new link points to the download for 10.7+.

This PR also moves the downloads for Julia 0.1 from Google Drive to AWS.