### PR TITLE
Do not MERGE: 3.4.6 vs. "Anaconda Python v3.5.4"

### DIFF
--- a/benchmarks/index.md
+++ b/benchmarks/index.md
@@ -42,7 +42,7 @@ Python, and Octave use <a
 href="https://github.com/xianyi/OpenBLAS">OpenBLAS</a> v0.2.19 for
 matrix operations; Mathematica uses Intel(R) MKL.  The Python
 environment is <a href="https://anaconda.org/anaconda/python">Anaconda
-Python</a> v3.5.4.  The Python implementations of
+Python</a> v3.4.6.  The Python implementations of
 <tt>rand_mat_stat</tt> and <tt>rand_mat_mul</tt> use <a
 href="http://www.numpy.org/">NumPy</a> v1.13.1 and OpenBLAS v0.2.19
 functions; the rest are pure Python implementations. Raw benchmark


### PR DESCRIPTION
The table seems inconsistent saying "3.4.6"; in case it is wrong (probably, I just didn't clearly see how to change the table), it should be synchronized.

Sync either way that is correct, or even better there's Python 3.6.x out, currently newest, and use it and matching Anaconda.