### PR TITLE
Add Ecosystems Page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,6 +17,8 @@ navigation:
     title: blog
   - url: "/community/"
     title: community
+  - url: "/ecosystems"
+    title: ecosystems
   - url: "/learning/"
     title: learning
   - url: "/teaching/"

--- a/ecosystems/index.md
+++ b/ecosystems/index.md
@@ -10,14 +10,14 @@ Most also have channels on the main Julia slack, and sub-forums on the main Juli
 
 ## International Localisation Efforts & Resources
 
-* [JuliaLangEs](https://github.com/JuliaLangEs) – Julia resources in the Spanish language ([Mailing-list(https://groups.google.com/forum/#!forum/julialanges)], [Twitter](https://twitter.com/JuliaLangsEs), [Discord](https://discord.me/julialang-es), [facebook](https://www.facebook.com/groups/julialang.es/), [WhatsApp](https://chat.whatsapp.com/invite/J9T033nZO8MLn96wWjlnHb))
+* [JuliaLangEs](https://github.com/JuliaLangEs) – Julia resources in the Spanish language ([Mailing-list](https://groups.google.com/forum/#!forum/julialanges)], [Twitter](https://twitter.com/JuliaLangsEs), [Discord](https://discord.me/julialang-es), [facebook](https://www.facebook.com/groups/julialang.es/), [WhatsApp](https://chat.whatsapp.com/invite/J9T033nZO8MLn96wWjlnHb))
 * [JuliaLangPt](https://github.com/JuliaLangPt) – Site for translation of Julia documentation, etc. to Portuguese ([Gitter](https://gitter.im/JuliaLangPt/julia))
 * [JuliaCN](https://github.com/JuliaCN) – An open-source organization for Julia localization in Chinese (QQ ID 188374671, )
 * [JuliaTokyo](https://github.com/JuliaTokyo) – Julia resources in the Japanese language ([Mailing-list](https://groups.google.com/forum/#!forum/julia-tokyo), [twitter](https://twitter.com/JuliaLangJa), [Slack](https://juliatokyo.slack.com),[Slack invite](https://julia-tokyo-inviter.herokuapp.com/), [facebook](https://www.facebook.com/groups/885166968160540/))
 
 ## General
 
-* [JuliaDocs](https://github.com/juliadocs) – Documentation-related packages for Julia ((Gitter)[https://gitter.im/juliadocs/users])
+* [JuliaDocs](https://github.com/juliadocs) – Documentation-related packages for Julia ([Gitter](https://gitter.im/juliadocs/users))
 * [Julia-i18n](https://github.com/Julia-i18n) – Internationalization (i18n) and localization (l10n) for Julians ([twitter](https://twitter.com/julia_i18n), [Gitter](https://gitter.im/Julia-i18n/julia-i18n) )
 * [JuliaTime](https://github.com/JuliaTime) – Date and time libraries
 * [JuliaText](https://github.com/JuliaText)

--- a/ecosystems/index.md
+++ b/ecosystems/index.md
@@ -1,0 +1,74 @@
+---
+layout: default
+title:  Julia Ecosystems
+---
+
+Julia has a wide ecosystem of packages, maintained by a wide variety of people.
+In the best of academic ideals, julia users from across the world come together to create mutually compatable and supporting packages for their domains.
+To manage these collections of packages they often use GitHub organisations and various other communication channels,
+Most also have channels on the main Julia slack, and sub-forums on the main Julia discourse (See [Community](../community)).
+
+## International Localisation Efforts & Resources
+
+* [JuliaLangEs](https://github.com/JuliaLangEs) – Julia resources in the Spanish language ([Mailing-list(https://groups.google.com/forum/#!forum/julialanges)], [Twitter](https://twitter.com/JuliaLangsEs), [Discord](https://discord.me/julialang-es), [facebook](https://www.facebook.com/groups/julialang.es/), [WhatsApp](https://chat.whatsapp.com/invite/J9T033nZO8MLn96wWjlnHb))
+* [JuliaLangPt](https://github.com/JuliaLangPt) – Site for translation of Julia documentation, etc. to Portuguese ([Gitter](https://gitter.im/JuliaLangPt/julia))
+* [JuliaCN](https://github.com/JuliaCN) – An open-source organization for Julia localization in Chinese (QQ ID 188374671, )
+* [JuliaTokyo](https://github.com/JuliaTokyo) – Julia resources in the Japanese language ([Mailing-list](https://groups.google.com/forum/#!forum/julia-tokyo), [twitter](https://twitter.com/JuliaLangJa), [Slack](https://juliatokyo.slack.com),[Slack invite](https://julia-tokyo-inviter.herokuapp.com/), [facebook](https://www.facebook.com/groups/885166968160540/))
+
+## General
+
+* [JuliaDocs](https://github.com/juliadocs) – Documentation-related packages for Julia ((Gitter)[https://gitter.im/juliadocs/users])
+* [Julia-i18n](https://github.com/Julia-i18n) – Internationalization (i18n) and localization (l10n) for Julians ([twitter](https://twitter.com/julia_i18n), [Gitter](https://gitter.im/Julia-i18n/julia-i18n) )
+* [JuliaTime](https://github.com/JuliaTime) – Date and time libraries
+* [JuliaText](https://github.com/JuliaText)
+* [JuliaPraxis](https://github.com/JuliaPraxis) - Best practices ([Gitter](https://gitter.im/JuliaPraxis))
+* [JuliaEditorSupport](https://github.com/JuliaEditorSupport) – Extensions/Plugins for text editors and IDEs
+* [Juno](https://github.com/JunoLab/Juno) - The Juno IDE for Atom [Gitter](https://gitter.im/JunoLab/Juno)
+
+## Computing
+
+* [JuliaArrays](https://github.com/JuliaArrays)
+* [JuliaBerry](https://github.com/JuliaBerry) – [Julia resources for the Raspberry Pi](https://juliaberry.github.io/)
+* [JuliaCI](https://github.com/JuliaCI) – Continuous Integration Support for Julia packages
+* [JuliaGPU](https://github.com/JuliaGPU) – GPU computing
+* [JuliaInterop](https://github.com/JuliaInterop) – Easy interoperability between Julia and not Julia
+* [JuliaIO](https://github.com/JuliaIO) – IO-related functionality, such as serialization
+* [JuliaParallel](https://github.com/JuliaParallel) – [Parallel programming in Julia](http://juliaparallel.github.io/)
+* [JuliaWeb](https://github.com/JuliaWeb) – Web stack
+
+
+
+
+## Mathematics
+
+* [JuliaDiff](https://github.com/JuliaDiff/) – [Differentiation tools](http://www.juliadiff.org/)
+* [JuliaDiffEq](https://github.com/JuliaDiffEq) – [Differential equation solving and analysis](https://juliadiffeq.github.io/), ([Gitter](https://gitter.im/JuliaDiffEq/Lobby))
+* [JuliaGeometry](https://github.com/JuliaGeometry) - Computational Geometry
+* [JuliaGraphs](https://github.com/JuliaGraphs) – Graph Theory and Implementation
+* [JuliaMath](https://github.com/JuliaMath) – Mathematics made easy in Julia
+* [JuliaOpt](https://github.com/JuliaOpt) – [Optimization](http://www.juliaopt.org/) ([Gitter](https://gitter.im/JuliaOpt/home))
+* [JuliaPolyhedra](https://github.com/JuliaPolyhedra) – [Polyhedral computation](https://juliapolyhedra.github.io/)
+* [JuliaSparse](https://github.com/JuliaSparse) – Sparse matrix solvers
+
+## Scientific Domains
+
+* [BioJulia](https://github.com/BioJulia) – Biology ([Gitter](https://gitter.im/BioJulia/home))
+* [EcoJulia](https://github.com/EcoJulia) – Ecology
+* [JuliaAstro](https://github.com/JuliaAstro) – Astronomy
+* [JuliaDSP](https://github.com/JuliaDSP) – Digital signal processing
+* [JuliaQuant](https://github.com/JuliaQuant) – Finance
+* [JuliaQuantum](https://github.com/JuliaQuantum) – [Julia libraries for quantum science and technology](http://juliaquantum.github.io/) ([Gitter](https://gitter.im/JuliaQuantum/home))
+
+## Data Science
+
+* [JuliaDB](https://github.com/JuliaDB) – Various database drivers for Julia
+* [JuliaImages](https://github.com/JuliaImages) - Image Processing
+* [JuliaML](https://github.com/JuliaML) - [Machine Learning](https://juliaml.github.io/)  ([JuliaML](https://gitter.im/JuliaML/chat))
+* [JuliaStats](https://github.com/JuliaStats) – [Statistics](http://www.juliastats.org/)
+
+## Visualization
+
+* [GiovineItalia](https://github.com/GiovineItalia) – Plotting (with [Gadfly](https://github.com/GiovineItalia/Gadfly.jl))
+* [JuliaPlots](https://github.com/JuliaPlots) – [Data visualization](https://juliaplots.github.io/)
+* [JuliaGL](https://github.com/JuliaGL) - OpenGL API and ecosystem ([Gitter](https://gitter.im/JuliaGL/meta))
+* [JuliaGraphics](https://github.com/JuliaGraphics) – Drawing, Colors, GUIs


### PR DESCRIPTION
This brings back the core of the content from https://github.com/JuliaLang/julialang.github.com/blob/23114cbcce56c57b6ba0536ca15a200d9dce9444/community/index.md

but reorganises it significantly,
In particular it is only by organisation (ecosystem if you will),
not by communication medium.
So I brought all the various chat links etc up inline.

Also I deleted a lot of stuff, like lists of particular packages.

It is now just about the various sub-ecosystems