### PR TITLE
Fix Python version # in benchmark table

### DIFF
--- a/_includes/benchmarks.html
+++ b/_includes/benchmarks.html
@@ -13,7 +13,7 @@
 </td><td class="version">V8 4.5.103.47
 </td><td class="version">R    '2017a'
 </td><td class="version">11.1.1
-</td><td class="version">3.4.6
+</td><td class="version">3.5.4
 </td><td class="version">3.3.1
 </td><td class="version">4.0.3
 </td></tr>


### PR DESCRIPTION
Corrected Python version to 3.5.4 in benchmark table, as noted in [PR 662]
(https://github.com/JuliaLang/julialang.github.com/pull/662).

Doing all the benchmark processing in the same Unix environment (same PATH) will avoid this error in the future. 