### PR TITLE
add korea manual URL

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -92,6 +92,7 @@ leading these efforts include:
 * [JuliaCN](https://julialang.cn) (Chinese)
 * [JuliaLangEs](https://github.com/JuliaLangEs) (Spanish)
 * [JuliaLangPt](https://github.com/JuliaLangPt) (Portuguese)
+* [JuliaKorea](https://juliakorea.github.io/ko/) (Korea)
 
 Please let us know if you have another organization dedicated to these efforts.
 

--- a/community/index.md
+++ b/community/index.md
@@ -92,7 +92,7 @@ leading these efforts include:
 * [JuliaCN](https://julialang.cn) (Chinese)
 * [JuliaLangEs](https://github.com/JuliaLangEs) (Spanish)
 * [JuliaLangPt](https://github.com/JuliaLangPt) (Portuguese)
-* [JuliaKorea](https://juliakorea.github.io/ko/) (Korea)
+* [JuliaKorea](https://juliakorea.github.io/ko/) (Korean)
 
 Please let us know if you have another organization dedicated to these efforts.
 


### PR DESCRIPTION
I add a manual link to translate in Korean.
This link is working on https://github.com/juliakorea/translate-doc