### PR TITLE
Blog Formatting

### DIFF
--- a/css/screen.css
+++ b/css/screen.css
@@ -215,11 +215,12 @@ code, table.benchmarks tbody {
 
 pre {
   border: 1px solid #ddd;
-  margin: 1em 0;
-  padding: .75em 1.25em;
-  line-height: 1em;
+  background: rgb(250, 250, 250);
+  margin: 1em -1.5em;
+  padding: 1em 1.5em;
   overflow: auto;
   direction: ltr;
+  border-radius: 5px;
 }
 
 .sidebar {
@@ -258,11 +259,43 @@ blockquote {
 /* Blog post pages */
 
 #blogpost {
-  margin-bottom: 3em;
+  max-width: 600px;
+  margin-left: auto;
+  margin-right: auto;
+  line-height: 1.75;
 }
+  #blogpost h1, h2 {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  }
   #blogpost .timestamp {
     color: #aaa;
   }
+  #blogpost > p {
+    text-align: justify;
+  }
+  #blogpost p code {
+    border: 1px solid #ddd;
+    background: rgb(250, 250, 250);
+    border-radius: 3px;
+    padding: 3px;
+  }
+  #blogpost blockquote {
+    color: rgb(100, 100, 100);
+    font-style: italic;
+    padding-left: 10px;
+    border-left: solid 3px rgb(200, 200, 200);
+  }
+  #blogpost .desc {
+    font-size: 75%;
+    text-align: right;
+    color: rgb(100, 100, 100);
+    border-top: 1px solid rgb(200, 200, 200);
+    padding-top: 5px;
+  }
+
+.footnotes ol {
+  margin-left: inherit;
+}
 
 #trackbacks {
   margin-bottom: 3em;


### PR DESCRIPTION
Not a drastic change, but makes various small things more readable. The previous wide column format really felt like a huge wall of text. Also adds quote formatting, inline code formatting, and a `desc` class for inline image captions.

<img width="1246" alt="screenshot 2017-12-04 16 56 17" src="https://user-images.githubusercontent.com/2234614/33571100-df215e58-d926-11e7-94ae-0c2748e29990.png">
<img width="1246" alt="screenshot 2017-12-04 16 56 31" src="https://user-images.githubusercontent.com/2234614/33571109-e12905a2-d926-11e7-9370-dbb88f1cf93c.png">
<img width="799" alt="screenshot 2017-12-04 19 12 06" src="https://user-images.githubusercontent.com/2234614/33571179-21901b94-d927-11e7-819a-7fc995dabf4b.png">

