### PR TITLE
Use MutationObserver API to avoid a null access error

### DIFF
--- a/_layouts/common.html
+++ b/_layouts/common.html
@@ -45,8 +45,26 @@
       var txPrompt = document.createElement( "li" );
       txPrompt.appendChild( txPromptLink );
 
-      // Add the translation prompt list item to the list of languages
-      document.getElementById( "tx-live-lang-picker" ).appendChild( txPrompt );
+      // Callback function to execute when mutations are observed
+      var callback = function(mutationsList, observer) {
+        for(var mutation of mutationsList) {
+          if (mutation.addedNodes.length >= 1) {
+            var addedNode = mutation.addedNodes[0];
+            if (addedNode.nodeType == Node.ELEMENT_NODE && addedNode.id == "tx-live-lang-picker") {
+              // Add the translation prompt list item to the list of languages
+              addedNode.appendChild( txPrompt );
+              // Stop observing the body element for mutations
+              observer.disconnect();
+            }
+          }
+        }
+      };
+
+      // Create an observer instance linked to the callback function
+      var observer = new MutationObserver(callback);
+
+      // Start observing the body element for adding and removal of child elements
+      observer.observe(document.body, { childList: true });
     </script>
 
 <!--Flipcause Integration v3.0// Flipcause Integration Instructions:

--- a/_layouts/common.html
+++ b/_layouts/common.html
@@ -45,6 +45,11 @@
       var txPrompt = document.createElement( "li" );
       txPrompt.appendChild( txPromptLink );
 
+      // The Transifex dropdown is created dynamically,
+      // so we need to use the DOM MutationObserver API
+      // (https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver)
+      // to know when the menu is ready so we can add our element to it.
+
       // Callback function to execute when mutations are observed
       var callback = function(mutationsList, observer) {
         for(var mutation of mutationsList) {


### PR DESCRIPTION
#686 had a flaw, in that if the script ran before the transifex dropdown had been instantiated, it would attempt to access a null element. This change should fix that.

See #687 for additional context. /cc @Ismael-VC and @ViralBShah.