### PR TITLE
Mark v0.5 as unmaintained

### DIFF
--- a/downloads/index.md
+++ b/downloads/index.md
@@ -63,7 +63,7 @@ issue in the Julia project](https://github.com/JuliaLang/julia/issues).
 
 Older releases of Julia for all platforms are available on the [Older releases page](http://julialang.org/downloads/oldreleases.html).
 
-For Julia 0.5, only bugfixes are being supported. Releases older than 0.5 are now unmaintained.
+Releases older than 0.6 are now unmaintained.
 
 # Nightly builds
 

--- a/downloads/oldreleases.md
+++ b/downloads/oldreleases.md
@@ -7,7 +7,7 @@ title:  Julia Downloads (Old releases)
 
 Old releases are available should you need to use them to run Julia
 code written for those releases.  Note that these are not actively developed
-anymore.
+nor maintained anymore.
 
 ## v0.5.2 (bugfixes only)
 <table class="downloads"><tbody>


### PR DESCRIPTION
Given the current pace of development of 0.7, the incompatibilities between 0.7 and 0.5, and the fact that we're very close to 1.0 (at which point _all_ pre-1.0 releases will be unmaintained), 0.5 is now unmaintained. This PR marks it as such. I'll also announce it on Discourse, and modify PackageEvaluator and pkg.julialang.org.