### PR TITLE
Another Julia Chinese Community.

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -89,7 +89,7 @@ and localize documentation and other resources. A few such groups that are
 leading these efforts include:
 
 * [JuliaTokyo](http://julia.tokyo) (Japanese)
-* [JuliaCN](https://julialang.cn) (Chinese)
+* [JulialangOrgCN](http://julialang.org.cn) (Chinese Simplified)
 * [JuliaLangEs](https://github.com/JuliaLangEs) (Spanish)
 * [JuliaLangPt](https://github.com/JuliaLangPt) (Portuguese)
 * [JuliaKorea](https://juliakorea.github.io/ko/) (Korean)


### PR DESCRIPTION
Because the old one (julialang.cn) can not access in China, even bypassed the GFW.

I apply for considering julialang.org.cn as a new Official Julia Chinese Community site, as alternative at least.