### PR TITLE
Include information about building system image

### DIFF
--- a/downloads/index.md
+++ b/downloads/index.md
@@ -59,6 +59,12 @@ trouble installing Julia.  Checksums for this release are available in both [MD5
 If the provided download files do not work for you, please [file an
 issue in the Julia project](https://github.com/JuliaLang/julia/issues).
 
+The binaries are built to be compatible with most machines. You can turn on all possible compiler optimizations by [building the Julia system image](https://docs.julialang.org/en/latest/devdocs/sysimg/) [for your machine](http://www.stochasticlifestyle.com/7-julia-gotchas-handle/). To do so, type at the Julia REPL:
+
+```julia
+julia> include(joinpath(dirname(JULIA_HOME),"share","julia","build_sysimg.jl")); build_sysimg(force=true)
+```
+
 # Older Releases
 
 Older releases of Julia for all platforms are available on the [Older releases page](http://julialang.org/downloads/oldreleases.html).


### PR DESCRIPTION
I have been using Julia for a couple of months now and did not come across http://www.stochasticlifestyle.com/7-julia-gotchas-handle/ until recently. 

If building the system image still does what is mentioned at that website (i.e., allow all compiler optimizations unlike the pre-built binaries), I think it is helpful to point that out early on to give new users better performance.