### PR TITLE
Add a GitHub star button

### DIFF
--- a/downloads/index.md
+++ b/downloads/index.md
@@ -3,6 +3,9 @@ layout: default
 title:  Julia Downloads
 ---
 
+If you like Julia, please consider starring us on GitHub and spreading the word!
+<iframe src="https://ghbtns.com/github-btn.html?user=JuliaLang&repo=julia&type=star&count=true" frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
+
 # Current Release (v0.6.2)
 
 We provide several ways for you to run Julia:


### PR DESCRIPTION
Currently on the downloads page but I can put it wherever.

The thing about this is that clicking the button does not and cannot star the project; that would require entering GitHub credentials and a call to the API, which is pretty sketchy. Instead it directs you to the GitHub page, where hopefully the person who clicks star on our page will be logged in and willing to click it on GitHub.

This is what it looks like:
![screenshot from 2018-02-22 12 26 01](https://user-images.githubusercontent.com/6396159/36562373-aebccba6-17cb-11e8-942b-fc5a9b5c03ac.png)
