### PR TITLE
Make the "Donate Now" button not look disabled

### DIFF
--- a/_layouts/common.html
+++ b/_layouts/common.html
@@ -222,7 +222,7 @@
 
 <!--END Flipcause Main Integration Code-->
 
-    <div style="background: #ccc; border-radius: 0px 0px 0px 0px; font-weight: normal;
+    <div style="background: #79afd2; border-radius: 0px 0px 0px 0px; font-weight: normal;
                 font-family: Arial, Helvetica, sans-serif; border: none; box-shadow: none;
                 left: 50%; margin-left: -72.5px; clear: both; display: block; width: 145px;
                 height: 45px; line-height: 2.8; position: relative; font-size: 16px;


### PR DESCRIPTION
The current color scheme is nice and unobtrusive, but it makes the button look like it's greyed-out and disabled.  This keeps it neutral but adds a color similar to the links on the page to make it clear that it can be clicked on.  Some discussion here: https://github.com/JuliaLang/julialang.github.com/issues/683

![image](https://user-images.githubusercontent.com/7132414/36926999-98ec93e6-1e2f-11e8-955d-e34ac71bfbcd.png)

