### PR TITLE
Classes using Julia: lexographical ordering and geo information

### DIFF
--- a/teaching/index.md
+++ b/teaching/index.md
@@ -19,38 +19,56 @@ a
 
 Julia is now being used in several universities and online courses. If you know of other classes using Julia for teaching, please consider [updating this list](https://github.com/JuliaLang/julialang.github.com/edit/master/teaching/index.md).
 
-- [TU Dortmund / SFB 823](https://www.statistik.tu-dortmund.de/sfb823.html), Germany
-  * One week introductory course into Julia with applications in statistics and economics ([Tileman Conring](https://www.statistik.tu-dortmund.de/conring.html)): Spring 2018
+- AGH University of Science and Technology, Poland <!--50.0657033,19.9189586670586-->
+  * [Signal processing in medical diagnostic systems](http://home.agh.edu.pl/~pieciak/en/dydaktyka/przetwarzanie-sygnalow-w-systemach-diagnostyki-medycznej) (Tomasz Pieciak), Spring 2015
 
-- [Federal University of Alagoas](http://www.ufal.edu.br) (_Universidade Federal de Alagoas_, UFAL)
-  * COMP272, Distributed Systems ([Prof. André Lage-Freitas](https://sites.google.com/a/ic.ufal.br/andrelage)): 2015, 2016, and 2017
+- Arizona State University <!--33.42165145,-111.932582859275-->
+  * MAT 423, Numerical Analysis (Prof. Clemens Heitzinger), Fall 2014
 
-- SGH Warsaw School of Economics, Poland
-  * 223490-0286, Statistical Learning Methods ([Bogumił Kamiński](http://bogumilkaminski.pl/about/)): Fall 2017, Spring 2018
-  * 234900-0286, Agent-Based Modeling ([Bogumił Kamiński](http://bogumilkaminski.pl/about/)): Fall 2017, Spring 2018
-  * 239420-0553, *Introduction to Deep Learning* module ([Bogumił Kamiński](http://bogumilkaminski.pl/about/)): Spring 2018
+- Azad University, Science and Research Branch <!--35.3068355,47.0064782-->
+  * CE 3820, Modeling and Evaluation (Dr. Arman Shokrollahi), Fall 2014
 
-- Federal Rural University of Rio de Janeiro (UFRRJ)
+- Brown University <!--41.8268682,-71.4012314581107-->
+  * [CSCI 1810](http://cs.brown.edu/courses/csci1810/), Computational Molecular Biology (Prof. Benjamin J. Raphael), Fall 2014
+
+- [Budapest University of Technology and Economics](www.bme.hu) <!--47.4796299,19.0561698643001-->
+  * [Applications of Differential Equations and Vector Analysis for Engineers II.] ([Brigitta Szilágyi](https://sites.google.com/site/brszilagyi/))
+
+- City University of New York <!--40.74851885,-73.9836392743124-->
+  * [MTH 229](http://wiener.math.csi.cuny.edu/verzani/classes/MTH229/), Calculus Computer Laboratory (Prof. John Verzani), Spring 2014. Also see the [MTH 229 Projects](http://mth229.github.io) page.
+
+- Cornell University <!--42.4489498,-76.4746831983026-->
+  * [CS 5220](http://www.cs.cornell.edu/~bindel/class/cs5220-s14/), Applications of Parallel Computers (Prof. David Bindel), Spring 2014
+
+- École Polytechnique Fédérale de Lausanne <!--46.5186594,6.566561505148-->
+  [CIVIL 557] [Decision-aid methodologies in transportation](Decision-aid methodologies in transportation) (Mor Kaspi, Virginie Lurkin), Spring 2017
+
+- [Einaudi Institute for Economics and Finance, Rome](www.eief.it) <!--41.907984,12.495731-->
+  * [Econometrics of DSGE Models](http://www.gragusa.org/teaching/eief_dsge) ([Giuseppe Ragusa](http://www.gragusa.org))
+
+- Emory University <!--33.7915703,-84.3183726165067-->
+  * [MATH 346](http://www.mathcs.emory.edu/~lruthot/courses/sp15-math346.html), Introduction to Optimization Theory (Prof. Lars Ruthotto), Spring 2015
+  * [MATH 516](http://www.mathcs.emory.edu/~lruthot/courses/math516.html), Numerical Analysis II (Prof. Lars Ruthotto), Spring 2015
+
+- Federal Rural University of Rio de Janeiro (UFRRJ) <!---22.768476,-43.685035-->
   * TM429, Introduction to Recommender Systems (Prof. [Filipe Braida](https://github.com/filipebraida)), Fall 2016, Spring 2017
 
-- Pontifical Catholic University of Rio de Janeiro (PUC-Rio)
-  * Programming in Julia (Prof. [Thuener Silva](https://github.com/Thuener)), Summer 2017
-  * Linear Optimization (Prof. [Alexandre Street](https://alexandrestreet.wordpress.com/)), Spring 2017
-  * Decision and Risk Analysis (Prof. [Davi Valladão](http://www.ind.puc-rio.br/es/equipe-dei/docentes/quadro-principal/davi-valladao/)), Fall 2015
-  
-- University of California, Los Angeles (UCLA)
-  * [Stat M230/Biomath 280/Biostat M280](http://hua-zhou.github.io/teaching/biostatm280-2017spring/), Statistical Computing, Spring 2017 (Prof. [Hua Zhou](https://github.com/Hua-Zhou))
+- [Federal University of Alagoas](http://www.ufal.edu.br) (_Universidade Federal de Alagoas_, UFAL) <!---9.555682,-35.777877-->
+  * COMP272, Distributed Systems ([Prof. André Lage-Freitas](https://sites.google.com/a/ic.ufal.br/andrelage)): 2015, 2016, and 2017
 
-- University of Antwerp, Faculty of Pharmaceutical, Biomedical, Veterinary Sciences, October 2016
-  * Computational Neuroscience (2070FBDBMW), Master of Biomedical Sciences, of Biochemistry, of Physics ([Michele Giugliano](https://www.uantwerpen.be/popup/opleidingsonderdeel.aspx?catalognr=2070FBDBMW&taal=nl&aj=2016))
+- Federal University of Uberlândia, Institute of Physics <!---18.918506,-48.25817-->
+  * [GFM050](http://www.infis.ufu.br/gerson), Física Computacional (Prof. Gerson J. Ferreira), Fall 2016
 
-- University of Glasgow, School of Mathematics and Statistics, September 2017
-  * An Introduction to Julia, course of Online Master of Science (MSc) in Data Analytics ([Theodore Papamarkou](http://www.gla.ac.uk/schools/mathematicsstatistics/staff/theodorepapamarkou/))
+- IIT Indore <!--22.52036,75.920723-->
+  * [ApplNLA](https://github.com/ivanslapnicar/GIAN-Applied-NLA-Course), Modern Applications of Numerical Linear Algebra (Prof. [Ivan Slapnicar](http://www.fesb.unist.hr/~slap/index1.html)), June 2016
 
-- Southcentral Kentucky Community and Technical College, Online, Fall 2017
-  * CIT 120 Computational Thinking (Inst. [Bryan Knowles](https://github.com/snotskie/))
+- Iowa State University <!--42.02791015,-93.6446441473745-->
+  * [STAT 590F](https://github.com/heike/stat590f), Topics in Statistical Computing: Julia Seminar (Prof. Heike Hofmann), Fall 2014
 
-- Massachusetts Institute of Technology (MIT)
+- [Luiss University Rome](www.luiss.it), [Department of Economics and Finance](http://economiaefinanza.luiss.it) <!--41.92150525,12.5132906979167-->
+  * [Econometric Theory](http://www.gragusa.org/teaching/et) ([Giuseppe Ragusa](http://www.gragusa.org))
+
+- Massachusetts Institute of Technology (MIT) <!--42.3583961,-71.0956778766393-->
   * [6.251/15.081](https://stellar.mit.edu/courseguide/course/6/fa15/6.251/), Introduction to Mathematical Programming (Prof. Dimitris J. Bertsimas), Fall 2015
   * [18.06](http://web.mit.edu/18.06/www/), Linear Algebra: Fall 2015, Dr. [Alex Townsend](https://github.com/ajt60gaibb); Fall 2014, Prof. Alexander Postnikov; Fall [2013](http://stellar.mit.edu/S/course/18/fa13/18.06), Prof. Alan Edelman
   * [18.303](http://math.mit.edu/~stevenj/18.303/), Linear Partial Differential Equations: Analysis and Numerics (Prof. [Steven G. Johnson](https://github.com/stevengj)), Fall 2013–2016.
@@ -64,131 +82,99 @@ Julia is now being used in several universities and online courses. If you know 
   * [15.S60](https://github.com/IainNZ/ORSoftwareTools2014), Software Tools for Operations Research (Iain Dunning), Spring 2014
   * [15.083](https://stellar.mit.edu/S/course/15/sp14/15.083/), Integer Programming and Combinatorial Optimization (Prof. Juan Pablo Vielma), Spring 2014
 
-- University of South Florida, Fall 2015
-  * [ESI 6491](http://www.chkwon.net/teaching/esi-6491/), Linear Programming and Network Optimization (Prof. Changhyun Kwon)
-
-- IIT Indore, June 24 - July 5, 2016
-  * [ApplNLA](https://github.com/ivanslapnicar/GIAN-Applied-NLA-Course), Modern Applications of Numerical Linear Algebra (Prof. [Ivan Slapnicar](http://www.fesb.unist.hr/~slap/index1.html))
-
-- [Université de Liège](http://www.ulg.ac.be/), Fall 2016
-  * [MATH0462](http://www.montefiore.ulg.ac.be/~tcuvelier/teaching/2016-2017-discrete-optimisation), Discrete Optimization (Prof. [Quentin Louveaux](http://www.montefiore.ulg.ac.be/~louveaux/))
-  * [MATH0461](http://progcours.ulg.ac.be/cocoon/cours/MATH0461-2.html), Introduction to Numerical Optimization (Prof. [Quentin Louveaux](http://www.montefiore.ulg.ac.be/~louveaux/))
-
-- École Polytechnique Fédérale de Lausanne, Spring 2017
-  [CIVIL 557] [Decision-aid methodologies in transportation](Decision-aid methodologies in transportation) (Mor Kaspi, Virginie Lurkin)
-
-- Northeastern University, Fall 2016
+- Northeastern University, Fall 2016 <!--42.34255795,-71.0905490240477-->
   * MTH3300: Applied Probability & Statistics
 
-- University of Sydney, Fall 2016
-  * [MATH3076/3976](http://www.maths.usyd.edu.au/u/olver/teaching/MATH3976/), Mathematical Computing (Assoc. Prof. [Sheehan Olver](http://www.maths.usyd.edu.au/u/olver/))
+- [Óbuda University](https://www.uni-obuda.hu), [John von Neumann Faculty of Informatics, Institute of Applied Mathematics](http://nik.uni-obuda.hu) <!--47.53837475,19.0333089565642-->
+  * [Intelligent Development Tools (Hungarian)]
+  * [Intelligent Development Tools (English)]
+  * [Fundamental Mathematical Methods (English)]
 
-- University of Cologne, Institute for Theoretical Physics
+- Pennsylvania State University <!--39.94560975,-79.6594009593437-->
+  * [ASTRO 585](http://www.personal.psu.edu/~ebf11/teach/astro585/), High-Performance Scientific Computing for Astrophysics (Prof. Eric B. Ford), Spring 2014 - [github repo](https://github.com/eford/Astro585_2014_Spring)
+  * [ASTRO 585](http://www.personal.psu.edu/~ebf11/teach/astro585/), High-Performance Scientific Computing for Astrophysics (Prof. Eric B. Ford), Fall 2015 - [github repo](https://github.com/eford/Astro585_2015_Fall_Public)
+
+- Pontifical Catholic University of Rio de Janeiro (PUC-Rio) <!---22.979107,-43.233083-->
+  * Programming in Julia (Prof. [Thuener Silva](https://github.com/Thuener)), Summer 2017
+  * Linear Optimization (Prof. [Alexandre Street](https://alexandrestreet.wordpress.com/)), Spring 2017
+  * Decision and Risk Analysis (Prof. [Davi Valladão](http://www.ind.puc-rio.br/es/equipe-dei/docentes/quadro-principal/davi-valladao/)), Fall 2015
+
+- Purdue University <!--40.4319722,-86.923893679845-->
+  * [CS51400](https://www.cs.purdue.edu/homes/dgleich/cs514-2016/), Numerical Analysis (Prof. [David Gleich](https://www.cs.purdue.edu/homes/dgleich/)), Spring 2016
+
+- "Sapienza" University of Rome, Italy <!--41.903763,12.514438-->
+  * [Operations Research](http://www.iasi.cnr.it/~liuzzi/teachita.htm) (Giampaolo Liuzzi), Spring 2015
+  * [Optimization for Complex Systems](http://www.iasi.cnr.it/~liuzzi/teachita.htm) (Giampaolo Liuzzi), Spring 2016
+
+- [Sciences Po Paris](http://www.sciencespo.fr), [Department of Economics](http://econ.sciences-po.fr), Spring 2016. <!--48.85389775,2.32902123126581-->
+  * [Computational Economics for PhDs](https://github.com/ScPo-CompEcon/Syllabus) ([Florian Oswald](https://floswald.github.io))
+
+- SGH Warsaw School of Economics, Poland <!--52.208872,21.008658-->
+  * 223490-0286, Statistical Learning Methods ([Bogumił Kamiński](http://bogumilkaminski.pl/about/)): Fall 2017, Spring 2018
+  * 234900-0286, Agent-Based Modeling ([Bogumił Kamiński](http://bogumilkaminski.pl/about/)): Fall 2017, Spring 2018
+  * 239420-0553, *Introduction to Deep Learning* module ([Bogumił Kamiński](http://bogumilkaminski.pl/about/)): Spring 2018
+
+- Southcentral Kentucky Community and Technical College <!--36.9844203,-86.4766572339932-->
+  * CIT 120 Computational Thinking (Inst. [Bryan Knowles](https://github.com/snotskie/)), Online, Fall 2017
+
+- Stanford University <!--37.431089,-122.169300939407-->
+  * [AA222](http://www.stanford.edu/class/aa222/), Introduction to Multidisciplinary Design Optimization (Prof. Mykel J. Kochenderfer), Spring 2014
+  * [AA228/CS238](http://www.stanford.edu/class/aa228/), Decision Making under Uncertainty (Prof. Mykel J. Kochenderfer), Fall 2014
+  * [EE103](http://stanford.edu/class/ee103/), Introduction to Matrix Methods (Prof. Stephen Boyd), Fall 2014
+  * [CME 257](https://github.com/icme/cme257-advanced-julia/), Advanced Topics in Scientific Computing with Julia (Mr. [Brad Nelson](https://github.com/bnels)), Fall 2015
+  * [EE103](http://stanford.edu/class/ee103/), Introduction to Matrix Methods (Prof. Stephen Boyd), Fall 2015
+
+- [TU Dortmund / SFB 823](https://www.statistik.tu-dortmund.de/sfb823.html), Germany <!--51.4915,7.41225-->
+  * One week introductory course into Julia with applications in statistics and economics ([Tileman Conring](https://www.statistik.tu-dortmund.de/conring.html)): Spring 2018
+
+- Universidad Nacional Autónoma de México <!--19.647012,-101.22900565-->
+  * [Física computacional](https://github.com/computo-fc/fisica_computacional) (Prof. David P. Sanders), Fall 2014
+  * Métodos numéricos para sistemas dinámicos (Prof. Luis Benet), Fall 2014
+  * [Métodos numéricos avanzados](https://github.com/dpsanders/MetodosNumericosAvanzados) (Prof. David P. Sanders and Prof. Luis Benet), Spring 2015
+  * [Métodos computacionales para la física estadística](https://github.com/dpsanders/metodos-monte-carlo) (Prof. David P. Sanders), Spring 2015
+
+- Universidad Nacional Pedro Ruiz Gallo, Lambayeque, Perú <!---6.707546,-79.9069734-->
+    * Julia: el lenguaje del futuro, [Semana de Integración de Ingeniería Electrónica](http://www.slideshare.net/Ownv94/lenguaje-julia-el-lenguaje-del-futuro), (Oscar William Neciosup Vera), Spring 2015
+
+- University at Buffalo <!--43.0015201,-78.7870697019128-->
+  * [IE 572](http://www.chkwon.net/teaching/ie-572/) Linear Programming (Prof. Changhyun Kwon), Fall 2014
+
+- University of Antwerp, Faculty of Pharmaceutical, Biomedical, Veterinary Sciences, October 2016 <!--51.22281,4.410232-->
+  * Computational Neuroscience (2070FBDBMW), Master of Biomedical Sciences, of Biochemistry, of Physics ([Michele Giugliano](https://www.uantwerpen.be/popup/opleidingsonderdeel.aspx?catalognr=2070FBDBMW&taal=nl&aj=2016))
+
+- University of California, Los Angeles (UCLA) <!--34.068921,-118.445181-->
+  * [Stat M230/Biomath 280/Biostat M280](http://hua-zhou.github.io/teaching/biostatm280-2017spring/), Statistical Computing, Spring 2017 (Prof. [Hua Zhou](https://github.com/Hua-Zhou))
+
+- University of Cologne, Institute for Theoretical Physics <!--50.928162,6.928819-->
   * [Computational Physics](http://www.thp.uni-koeln.de/trebst/Lectures/2016-CompPhys.shtml) (Prof. Simon Trebst), Summer 2016
   * [Computational Physics](http://www.thp.uni-koeln.de/~bulla/cp-ss17.html) (Prof. Ralf Bulla), Summer 2017
   * [Statistical Physics](http://www.thp.uni-koeln.de/trebst/Lectures/2017-StatPhys.shtml) (Prof. Simon Trebst), Winter 2017
   * [Computational Many-Body Physics](http://www.thp.uni-koeln.de/trebst/Lectures/2018-CompManyBody.shtml) (Prof. Simon Trebst), Summer 2018
 
-- [Óbuda University](https://www.uni-obuda.hu), [John von Neumann Faculty of Informatics, Institute of Applied Mathematics](http://nik.uni-obuda.hu)
-  * [Intelligent Development Tools (Hungarian)]
-  * [Intelligent Development Tools (English)]
-  * [Fundamental Mathematical Methods (English)]
-
-- [Budapest University of Technology and Economics](www.bme.hu)
-  * [Applications of Differential Equations and Vector Analysis for Engineers II.] ([Brigitta Szilágyi](https://sites.google.com/site/brszilagyi/))
-
-- [Luiss University Rome](www.luiss.it), [Department of Economics and Finance](http://economiaefinanza.luiss.it)
-  * [Econometric Theory](http://www.gragusa.org/teaching/et) ([Giuseppe Ragusa](http://www.gragusa.org))
-
-- [Einaudi Institute for Economics and Finance, Rome](www.eief.it)
-  * [Econometrics of DSGE Models](http://www.gragusa.org/teaching/eief_dsge) ([Giuseppe Ragusa](http://www.gragusa.org))
-
-- [Sciences Po Paris](http://www.sciencespo.fr), [Department of Economics](http://econ.sciences-po.fr), Spring 2016.
-  * [Computational Economics for PhDs](https://github.com/ScPo-CompEcon/Syllabus) ([Florian Oswald](https://floswald.github.io))
-
-- Federal University of Uberlândia, Institute of Physics, Fall 2016
-  * [GFM050](http://www.infis.ufu.br/gerson), Física Computacional (Prof. Gerson J. Ferreira)
-
-- "Sapienza" University of Rome, Italy, Spring 2016
-  * [Optimization for Complex Systems](http://www.iasi.cnr.it/~liuzzi/teachita.htm) (Giampaolo Liuzzi)
-
-- Purdue University, Spring 2016
-  * [CS51400](https://www.cs.purdue.edu/homes/dgleich/cs514-2016/), Numerical Analysis (Prof. [David Gleich](https://www.cs.purdue.edu/homes/dgleich/))
-
-- University of Edinburgh
+- University of Edinburgh <!--55.94938435,-3.18005288130257-->
   * Spring 2017, [MATH11146](http://www.drps.ed.ac.uk/16-17/dpt/cxmath11146.htm), Modern optimization methods for big data problems (Prof. [Peter Richtarik](http://www.maths.ed.ac.uk/~prichtar/index.html))
   * Spring 2016, [MATH11146](http://www.drps.ed.ac.uk/15-16/dpt/cxmath11146.htm), Modern optimization methods for big data problems (Prof. [Peter Richtarik](http://www.maths.ed.ac.uk/~prichtar/index.html))
 
-- University of South Florida, Spring 2016
-  * [EIN 6945](http://www.chkwon.net/teaching/ein-6935/), Nonlinear Optimization and Game Theory (Prof. [Changhyun Kwon](http://www.chkwon.net/))
+- University of Glasgow, School of Mathematics and Statistics <!--55.87230815,-4.28922544277935-->
+  * An Introduction to Julia, course of Online Master of Science (MSc) in Data Analytics ([Theodore Papamarkou](http://www.gla.ac.uk/schools/mathematicsstatistics/staff/theodorepapamarkou/)), September 2017
 
-- Universidad Nacional Pedro Ruiz Gallo, Lambayeque, Perú, Spring 2015
-    * Julia: el lenguaje del futuro, [Semana de Integración de Ingeniería Electrónica](http://www.slideshare.net/Ownv94/lenguaje-julia-el-lenguaje-del-futuro), (Oscar William Neciosup Vera)
+- University of South Florida <!--28.0599999,-82.4138361902512-->
+  * [ESI 6491](http://www.chkwon.net/teaching/esi-6491/), Linear Programming and Network Optimization (Prof. Changhyun Kwon), Fall 2015
+  * [EIN 6945](http://www.chkwon.net/teaching/ein-6935/), Nonlinear Optimization and Game Theory (Prof. [Changhyun Kwon](http://www.chkwon.net/)), Spring 2016
 
-- [Université de Liège](http://www.ulg.ac.be/), Fall 2015
-  * [MATH0462](http://www.montefiore.ulg.ac.be/~tcuvelier/teaching/2015-2016-discrete-optimisation), Discrete Optimization (Prof. [Quentin Louveaux](http://www.montefiore.ulg.ac.be/~louveaux/))
+- University of Sydney <!---33.88902715,151.189420694852-->
+  * [MATH3076/3976](http://www.maths.usyd.edu.au/u/olver/teaching/MATH3976/), Mathematical Computing (Assoc. Prof. [Sheehan Olver](http://www.maths.usyd.edu.au/u/olver/)), Fall 2016
 
-- Université Paul Sabatier, Toulouse, Fall 2015
-  * [Optimization in Machine Learning](http://www.irit.fr/cimi-machine-learning/node/15), (Prof. [Peter Richtarik](http://www.maths.ed.ac.uk/~prichtar/))
+- Université Paul Sabatier, Toulouse <!--43.5601417,1.4635117-->
+  * [Optimization in Machine Learning](http://www.irit.fr/cimi-machine-learning/node/15), (Prof. [Peter Richtarik](http://www.maths.ed.ac.uk/~prichtar/)), Fall 2015
 
-- Stanford, Fall 2015
-  * [CME 257](https://github.com/icme/cme257-advanced-julia/), Advanced Topics in Scientific Computing with Julia (Mr. [Brad Nelson](https://github.com/bnels))
-  * [EE103](http://stanford.edu/class/ee103/), Introduction to Matrix Methods (Prof. Stephen Boyd)
+- [Université de Liège](http://www.ulg.ac.be/) <!--50.64080705,5.57643469040658-->
+  * [MATH0462](http://www.montefiore.ulg.ac.be/~tcuvelier/teaching/2016-2017-discrete-optimisation), Discrete Optimization (Prof. [Quentin Louveaux](http://www.montefiore.ulg.ac.be/~louveaux/)), Fall 2016
+  * [MATH0461](http://progcours.ulg.ac.be/cocoon/cours/MATH0461-2.html), Introduction to Numerical Optimization (Prof. [Quentin Louveaux](http://www.montefiore.ulg.ac.be/~louveaux/)), Fall 2016
+  * [MATH0462](http://www.montefiore.ulg.ac.be/~tcuvelier/teaching/2015-2016-discrete-optimisation), Discrete Optimization (Prof. [Quentin Louveaux](http://www.montefiore.ulg.ac.be/~louveaux/)), Fall 2015
 
-- Pennsylvania State University, Fall 2015
-  * [ASTRO 585](http://www.personal.psu.edu/~ebf11/teach/astro585/), High-Performance Scientific Computing for Astrophysics (Prof. Eric B. Ford) - [github repo](https://github.com/eford/Astro585_2015_Fall_Public)
-
-- "Sapienza" University of Rome, Italy, Spring 2015
-  * [Operations Research](http://www.iasi.cnr.it/~liuzzi/teachita.htm) (Giampaolo Liuzzi)
-
-- AGH University of Science and Technology, Poland, Spring 2015
-  * [Signal processing in medical diagnostic systems](http://home.agh.edu.pl/~pieciak/en/dydaktyka/przetwarzanie-sygnalow-w-systemach-diagnostyki-medycznej) (Tomasz Pieciak)
-
-- Universidad Nacional Autónoma de México, Spring 2015
-  * [Métodos numéricos avanzados](https://github.com/dpsanders/MetodosNumericosAvanzados) (Prof. David P. Sanders and Prof. Luis Benet)
-  * [Métodos computacionales para la física estadística](https://github.com/dpsanders/metodos-monte-carlo) (Prof. David P. Sanders)
-
-- Arizona State University, Fall 2014
-  * MAT 423, Numerical Analysis (Prof. Clemens Heitzinger)
-
-- Azad University, Science and Research Branch, Fall 2014
-  * CE 3820, Modeling and Evaluation (Dr. Arman Shokrollahi)
-
-- Brown University, Fall 2014
-  * [CSCI 1810](http://cs.brown.edu/courses/csci1810/), Computational Molecular Biology (Prof. Benjamin J. Raphael)
-
-- Emory University, Spring 2015
-  * [MATH 346](http://www.mathcs.emory.edu/~lruthot/courses/sp15-math346.html), Introduction to Optimization Theory (Prof. Lars Ruthotto)
-  * [MATH 516](http://www.mathcs.emory.edu/~lruthot/courses/math516.html), Numerical Analysis II (Prof. Lars Ruthotto)
-
-- Iowa State University, Fall 2014
-  * [STAT 590F](https://github.com/heike/stat590f), Topics in Statistical Computing: Julia Seminar (Prof. Heike Hofmann)
-
-- Stanford University, Fall 2014
-  * [AA228/CS238](http://www.stanford.edu/class/aa228/), Decision Making under Uncertainty (Prof. Mykel J. Kochenderfer)
-  * [EE103](http://stanford.edu/class/ee103/), Introduction to Matrix Methods (Prof. Stephen Boyd)
-
-- Universidad Nacional Autónoma de México, Fall 2014
-  * [Física computacional](https://github.com/computo-fc/fisica_computacional) (Prof. David P. Sanders)
-  * Métodos numéricos para sistemas dinámicos (Prof. Luis Benet)
-
-- University at Buffalo, Fall 2014
-  * [IE 572](http://www.chkwon.net/teaching/ie-572/) Linear Programming (Prof. Changhyun Kwon)
-
-- City University of New York, Spring 2014
-  * [MTH 229](http://wiener.math.csi.cuny.edu/verzani/classes/MTH229/), Calculus Computer Laboratory (Prof. John Verzani). Also see the [MTH 229 Projects](http://mth229.github.io) page.
-
-- Cornell University, Spring 2014
-  * [CS 5220](http://www.cs.cornell.edu/~bindel/class/cs5220-s14/), Applications of Parallel Computers (Prof. David Bindel)
-
-- Pennsylvania State University, Spring 2014
-  * [ASTRO 585](http://www.personal.psu.edu/~ebf11/teach/astro585/), High-Performance Scientific Computing for Astrophysics (Prof. Eric B. Ford) - [github repo](https://github.com/eford/Astro585_2014_Spring)
-
-- Stanford University, Spring 2014
-  * [AA222](http://www.stanford.edu/class/aa222/), Introduction to Multidisciplinary Design Optimization (Prof. Mykel J. Kochenderfer)
-
-- Western University Canada, Fall 2013
-  * [CS 2101A](http://www.csd.uwo.ca/~moreno/cs2101a_moreno/index.html), Foundations of Programming for High Performance Computing. (Prof. Marc Moreno Maza)
+- Western University Canada <!--43.00535865,-81.2748046243065-->
+  * [CS 2101A](http://www.csd.uwo.ca/~moreno/cs2101a_moreno/index.html), Foundations of Programming for High Performance Computing. (Prof. Marc Moreno Maza), Fall 2013
 
 ## Installing Julia
 


### PR DESCRIPTION
See #764. This PR does the following:

* merges multiple separate entries of same institution
* sorts lexographically by institution name
* puts time information (i.e. "Fall 2015") on course rather than institution
* adds (approximate) geo location (latitude and longitude) to institutions in the form of invisible html comments. This is a preparation for integrating the interactive map (see http://github.com/crstnbr/juliamap).

I hope the html comments containing the geo information are really hidden. Github preview says they are but I couldn't check because I don't have Docker available.