### PR TITLE
Add Optim.jl JOSS article

### DIFF
--- a/_publications/PKMANR18.md
+++ b/_publications/PKMANR18.md
@@ -1,0 +1,17 @@
+---
+type: "article"
+title: "Optim: A mathematical optimization package for {Julia}"
+journal: "Journal of Open Source Software"
+authors:
+- Patrick Kofod Mogensen
+- Asbjørn Nilsen Riseth
+year: "2018"
+volume: "3"
+issue: "24"
+pages: "615"
+doi: "10.21105/joss.00615"
+packages:
+  Optim.jl: https://github.com/JuliaNLSolvers/Optim.jl
+  LineSearches.jl: https://github.com/JuliaNLSolvers/LineSearches.jl
+---
+

--- a/_publications/PKMANR18.md
+++ b/_publications/PKMANR18.md
@@ -1,6 +1,6 @@
 ---
 type: "article"
-title: "Optim: A mathematical optimization package for {Julia}"
+title: "Optim: A mathematical optimization package for Julia"
 journal: "Journal of Open Source Software"
 authors:
 - Patrick Kofod Mogensen
@@ -14,4 +14,3 @@ packages:
   Optim.jl: https://github.com/JuliaNLSolvers/Optim.jl
   LineSearches.jl: https://github.com/JuliaNLSolvers/LineSearches.jl
 ---
-


### PR DESCRIPTION
We have submitted a JOSS article on Optim.jl that has just been published, and hope you can add it to the list of publications on julialang.

Should the title have brackets around Julia as in BiBTeX?

Ref @pkofod 