### PR TITLE
Improve consistancy and fix typos

### DIFF
--- a/ecosystems/index.md
+++ b/ecosystems/index.md
@@ -23,7 +23,7 @@ Most also have channels on the main Julia Slack channel, and sub-forums on the m
 * [JuliaTime](https://github.com/JuliaTime) – Date and time libraries
 * [JuliaPraxis](https://github.com/JuliaPraxis) – Best practices ([Gitter](https://gitter.im/JuliaPraxis))
 * [JuliaEditorSupport](https://github.com/JuliaEditorSupport) – Extensions/Plugins for text editors and IDEs
-* [Juno](https://github.com/JunoLab) – The Juno IDE for Atom [Gitter](https://gitter.im/JunoLab/Juno)
+* [Juno](https://github.com/JunoLab) – The Juno IDE for Atom ([Gitter](https://gitter.im/JunoLab/Juno))
 
 ## Computing
 

--- a/ecosystems/index.md
+++ b/ecosystems/index.md
@@ -10,11 +10,11 @@ Most also have channels on the main Julia Slack channel, and sub-forums on the m
 
 ## International Localisation Efforts & Resources
 
-* [JuliaLangEs](https://github.com/JuliaLangEs) – Julia resources in the Spanish language ([Mailing-list](https://groups.google.com/forum/#!forum/julialanges)], [Twitter](https://twitter.com/JuliaLangsEs), [Discord](https://discord.me/julialang-es), [Facebook](https://www.facebook.com/groups/julialang.es/), [WhatsApp](https://chat.whatsapp.com/invite/J9T033nZO8MLn96wWjlnHb))
-* [JuliaLangPt](https://github.com/JuliaLangPt) – Site for translation of Julia documentation, etc. to Portuguese ([Gitter](https://gitter.im/JuliaLangPt/julia))
+* [JuliaLangEs](https://github.com/JuliaLangEs) – Julia resources in the Spanish language ([Mailing-list](https://groups.google.com/forum/#!forum/julialanges), [Twitter](https://twitter.com/JuliaLangsEs), [Discord](https://discord.me/julialang-es), [Facebook](https://www.facebook.com/groups/julialang.es/), [WhatsApp](https://chat.whatsapp.com/invite/J9T033nZO8MLn96wWjlnHb))
+* [JuliaLangPt](https://github.com/JuliaLangPt) – Julia resources in the Portuguese language ([Gitter](https://gitter.im/JuliaLangPt/julia))
 * [JuliaCN](https://github.com/JuliaCN) – An open-source organization for Julia localization in Chinese (QQ ID 188374671, )
 * [JuliaTokyo](https://github.com/JuliaTokyo) – Julia resources in the Japanese language ([Mailing-list](https://groups.google.com/forum/#!forum/julia-tokyo), [Twitter](https://twitter.com/JuliaLangJa), [Slack](https://juliatokyo.slack.com), [Slack invite](https://julia-tokyo-inviter.herokuapp.com/), [Facebook](https://www.facebook.com/groups/885166968160540/))
-* [JuliaGerman](https://github.com/JuliaLangGerman) – German manual for the Julia language ([manual](https://github.com/JuliaLangGerman/Julia_Handbuch_Deutsch))
+* [JuliaGerman](https://github.com/JuliaLangGerman) – Julia resources in the German language ([manual](https://github.com/JuliaLangGerman/Julia_Handbuch_Deutsch))
 
 ## General
 
@@ -61,7 +61,7 @@ Most also have channels on the main Julia Slack channel, and sub-forums on the m
 * [JuliaDynamics](https://github.com/JuliaDynamics) - [Dynamical systems](https://juliadynamics.github.io/DynamicalSystems.jl/latest/), nonlinear dynamics and chaos.
 
 ## Data Science
-* [JuliaML](https://github.com/JuliaML) – [Machine Learning](https://juliaml.github.io/)  ([JuliaML](https://gitter.im/JuliaML/chat))
+* [JuliaML](https://github.com/JuliaML) – [Machine Learning](https://juliaml.github.io/)  ([Gitter](https://gitter.im/JuliaML/chat))
 * [JuliaStats](https://github.com/JuliaStats) – [Statistics](http://juliastats.github.io/)
 * [JuliaImages](https://github.com/JuliaImages) – Image Processing
 * [JuliaText](https://github.com/JuliaText) – Natural Language Processing (NLP), Computational Linguistics  and (textual) Information Retrieval


### PR DESCRIPTION
These typos have been bugging me for while
Also while I was here I made  some of the internationalization resource uses similar descriptions because they have similar content.