### PR TITLE
Fix footnotes syntax in missing values blog post

### DIFF
--- a/blog/_posts/2018-06-19-missing.md
+++ b/blog/_posts/2018-06-19-missing.md
@@ -19,10 +19,11 @@ implicit propagation of null values (they require
 [lifting](https://blogs.msdn.microsoft.com/ericlippert/2007/06/27/what-exactly-does-lifted-mean/))
 and do not provide an efficient representation of arrays with missing values[^nullable].
 
-[^nullable]: [C#](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/nullable-types/using-nullable-types)
-(with `null`) and [VB.NET](https://docs.microsoft.com/en-us/dotnet/visual-basic/programming-guide/language-features/data-types/nullable-value-types)
-(with `Nothing`) are two partial exceptions to this rule, since they provide
-*lifted* operators which operate on `Nullable` arguments and return `Nullable`s.
+[^nullable]:
+    [C#](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/nullable-types/using-nullable-types)
+    (with `null`) and [VB.NET](https://docs.microsoft.com/en-us/dotnet/visual-basic/programming-guide/language-features/data-types/nullable-value-types)
+    (with `Nothing`) are two partial exceptions to this rule, since they provide
+    *lifted* operators which operate on `Nullable` arguments and return `Nullable`s.
 
 Starting from Julia 0.7, missing values are represented using the new `missing` object.
 Resulting from intense design discussions, experimentations and language
@@ -38,10 +39,11 @@ as the most consistent implementations with regard to the support of missing val
 Incidentally, this makes it easy to generate SQL requests from Julia code or to have
 R and Julia interoperate.
 
-[^PDA]: The `PooledDataArray` type shipped in the same package can be replaced with
-either [`CategoricalArray`](https://github.com/JuliaData/CategoricalArrays.jl) or
-[`PooledArray`](https://github.com/JuliaComputing/PooledArrays.jl) depending on whether
-the data is really categorical or simply contains a small number of distinct values.
+[^PDA]:
+    The `PooledDataArray` type shipped in the same package can be replaced with
+    either [`CategoricalArray`](https://github.com/JuliaData/CategoricalArrays.jl) or
+    [`PooledArray`](https://github.com/JuliaComputing/PooledArrays.jl) depending on whether
+    the data is really categorical or simply contains a small number of distinct values.
 
 This framework is used by
 [version 0.11](https://discourse.julialang.org/t/dataframes-0-11-released/7296/)
@@ -100,10 +102,11 @@ rather than `Any`[^typejoin]:
     julia> promote_type(Int, Missing)
     Union{Missing, Int64}
 
-[^typejoin]: In addition to these `promote_rule` methods, the `Missing` and `Nothing` types
-implement the internal `promote_typejoin` function, which ensures that functions such
-as `map` and `collect` return arrays with element types `Union{Missing,T}` or
-`Union{Nothing,T}` instead of `Any`.
+[^typejoin]:
+    In addition to these `promote_rule` methods, the `Missing` and `Nothing` types
+    implement the internal `promote_typejoin` function, which ensures that functions such
+    as `map` and `collect` return arrays with element types `Union{Missing,T}` or
+    `Union{Nothing,T}` instead of `Any`.
 
 These promotion rules are essential for performance, as we will see below.
 
@@ -120,15 +123,16 @@ Sentinel approaches also suffer from bugs in corner cases: for example, in R,
 `NA + NaN` returns `NA` but `NaN + NA` returns `NaN` due to floating point
 computation rules.
 
-[^lt]: More precisely, SAS considers missing values as smaller than any non-missing
-value, and Stata considers them as greater than any non-missing value. This behavior
-can be explained by the particular choice of sentinel values of each of these languages
-and by an imperfect abstraction revealing implementation details.
+[^lt]:
+    More precisely, SAS considers missing values as smaller than any non-missing
+    value, and Stata considers them as greater than any non-missing value. This behavior
+    can be explained by the particular choice of sentinel values of each of these languages
+    and by an imperfect abstraction revealing implementation details.
 
-[^35h]: See for example Olivier Godechot's
-["Can We Use Alsace-Moselle for Estimating the Employment Effects of the 35-Hour
-Workweek Regulation in France?"](
-http://olivier.godechot.free.fr/hopfichiers/fichierspub/Comment_on_Chemin_Wasmer_2009_Jole.pdf).
+[^35h]:
+    See for example Olivier Godechot's
+    ["Can We Use Alsace-Moselle for Estimating the Employment Effects of the 35-Hour Workweek Regulation in France?"](
+    http://olivier.godechot.free.fr/hopfichiers/fichierspub/Comment_on_Chemin_Wasmer_2009_Jole.pdf).
 
 Therefore, passing `missing` to a function will always return `missing` or throw
 an error (except for a few special functions presented below). For convenience,
@@ -254,10 +258,11 @@ While it is similar to the previous `NA` value, the new `missing` object also re
 the `Nullable` type introduced in Julia 0.4, which turned out not to be the best choice
 to represent missing values[^jmw]. `Nullable` suffered from several issues:
 
-[^jmw]: In [a 2014 blog post](http://www.johnmyleswhite.com/notebook/2014/11/29/whats-wrong-with-statistics-in-julia/),
-John Myles White advocated the use of `Nullable` due to its much higher performance
-compared with`Union{T,NA}`. This performance gap no longer exists thanks to compiler
-improvements which have been a game-changer for missing values support.
+[^jmw]:
+    In [a 2014 blog post](http://www.johnmyleswhite.com/notebook/2014/11/29/whats-wrong-with-statistics-in-julia/),
+    John Myles White advocated the use of `Nullable` due to its much higher performance
+    compared with`Union{T,NA}`. This performance gap no longer exists thanks to compiler
+    improvements which have been a game-changer for missing values support.
 
 - It was used to represent two very different kinds of missingness, that we
   sometimes call respectively the "software engineer's null" and the "data
@@ -325,9 +330,10 @@ inferred as a small `Union`: it is therefore essential to work with
 `Array{Union{Missing,T}}` rather than `Array{Any}` objects, to provide the compiler
 with the necessary type information.
 
-[^splitting]: This optimization applies to all `Union`s of a small number of types,
-whether they are bits types or not. "Small" is defined by the `MAX_UNION_SPLITTING`
-constant, which is currently set to 4.
+[^splitting]:
+    This optimization applies to all `Union`s of a small number of types,
+    whether they are bits types or not. "Small" is defined by the `MAX_UNION_SPLITTING`
+    constant, which is currently set to 4.
 
 The second improvement consists in using a compact memory layout for `Array` object
 whose element type is a `Union` of bits types, i.e. immutable types which contain


### PR DESCRIPTION
Added in https://github.com/JuliaLang/julialang.github.com/pull/770.