### PR TITLE
Enable Julia syntax highlighting in missing values post

### DIFF
--- a/blog/_posts/2018-06-19-missing.md
+++ b/blog/_posts/2018-06-19-missing.md
@@ -66,7 +66,7 @@ The post first presents the behavior of the new `missing` object, and then detai
 implementation, in particular showing how it provides blazing performance while still
 being fully generic. Finally, current limitations and future improvements are discussed.
 
-## The `missing` object: safe and generic missing values
+## The 'missing' object: safe and generic missing values
 
 One of Julia's strengths is that user-defined types are as powerful and fast as built-in
 types. To fully take advantage of this, missing values had to support not only standard
@@ -86,10 +86,12 @@ of useful methods are implemented. Values which can be either of type `T` or mis
 can simply be declared as `Union{Missing,T}`. For example, a vector holding either integers
 or missing values is of type `Array{Union{Missing,Int},1}`:
 
-    julia> [1, missing]
-    2-element Array{Union{Missing, Int64},1}:
-    1
-    missing
+```julia
+julia> [1, missing]
+2-element Array{Union{Missing, Int64},1}:
+ 1       
+  missing
+```
 
 An interesting property of this approach is that `Array{Union{Missing,T}}` behaves just
 like a normal `Array{T}` as soon as missing values have been replaced or skipped
@@ -99,8 +101,10 @@ As can be seen in the example above, promotion rules are defined so that concate
 values of type `T` and missing values gives an array with element type `Union{Missing,T}`
 rather than `Any`[^typejoin]:
 
-    julia> promote_type(Int, Missing)
-    Union{Missing, Int64}
+```julia
+julia> promote_type(Int, Missing)
+Union{Missing, Int64}
+```
 
 [^typejoin]:
     In addition to these `promote_rule` methods, the `Missing` and `Nothing` types
@@ -139,85 +143,95 @@ an error (except for a few special functions presented below). For convenience,
 standard operators and mathematical functions systematically propagate missing
 values:
 
-    julia> 1 + missing
-    missing
+```julia
+julia> 1 + missing
+missing
 
-    julia> missing^2
-    missing
+julia> missing^2
+missing
 
-    julia> cos(missing)
-    missing
+julia> cos(missing)
+missing
 
-    julia> round(missing)
-    missing
+julia> round(missing)
+missing
 
-    julia> "a" * missing
-    missing
+julia> "a" * missing
+missing
+```
 
 Reduction operations inherit the propagating behavior of basic operators:
 
-    julia> sum([1, missing, 2])
-    missing
+```julia
+julia> sum([1, missing, 2])
+missing
 
-    julia> mean([1, missing, 2])
-    missing
+julia> mean([1, missing, 2])
+missing
+```
 
 On the other hand, indexing into a `Vector` with missing values is an error.
 Missing values are *not* silently skipped, which would be equivalent to assuming
 that they are `false`.
 
-    julia> x = 1:3
-    1:3
+```julia
+julia> x = 1:3
+1:3
 
-    julia> x[[true, missing, false]]
-    ERROR: ArgumentError: unable to check bounds for indices of type Missing
+julia> x[[true, missing, false]]
+ERROR: ArgumentError: unable to check bounds for indices of type Missing
 
-    julia> x[[1, missing]]
-    ERROR: ArgumentError: unable to check bounds for indices of type Missing
+julia> x[[1, missing]]
+ERROR: ArgumentError: unable to check bounds for indices of type Missing
+```
 
 Convenience functions are provided to get rid of missing values explicitly.
 First, the `skipmissing` function returns an iterator over the non-missing values
 in the passed collection. It is particularly useful to ignore missing values when
 computing reductions. Call `collect` to obtain a vector with all non-missing values.
 
-    julia> sum(skipmissing([1, missing, 2]))
-    3
+```julia
+julia> sum(skipmissing([1, missing, 2]))
+3
 
-    julia> mean(skipmissing([1, missing, 2]))
-    1.5
+julia> mean(skipmissing([1, missing, 2]))
+1.5
 
-    julia> collect(skipmissing([1, missing, 2]))
-    2-element Array{Int64,1}:
-    1
-    2
+julia> collect(skipmissing([1, missing, 2]))
+2-element Array{Int64,1}:
+1
+2
 
-    julia> x[collect(skipmissing([1, missing, 2]))]
-    2-element Array{Int64,1}:
-    1
-    2
+julia> x[collect(skipmissing([1, missing, 2]))]
+2-element Array{Int64,1}:
+1
+2
+```
 
 Second, the `coalesce` function returns the first non-missing argument (as in SQL),
 which as a special case allows replacing missing values with a particular value.
 Combined with the "dot" broadcasting syntax, it allows replacing all missing
 values in an array:
 
-    julia> coalesce(missing, 0)
-    0
+```julia
+julia> coalesce(missing, 0)
+0
 
-    julia> coalesce(missing, missing, 0)
-    0
+julia> coalesce(missing, missing, 0)
+0
 
-    julia> coalesce.([1, missing, 2], 0)
-    3-element Array{Int64,1}:
-    1
-    0
-    2
+julia> coalesce.([1, missing, 2], 0)
+3-element Array{Int64,1}:
+1
+0
+2
 
-    julia> coalesce.([1, missing, 2], [2, 3, missing])
-    3-element Array{Int64,1}:
-    1
-    3
-    2
+julia> coalesce.([1, missing, 2], [2, 3, missing])
+3-element Array{Int64,1}:
+1
+3
+2
+```
 
 A restricted set of functions and operators follow different semantics than
 those described above. They can be grouped into four classes:
@@ -252,7 +266,7 @@ See the [manual](https://docs.julialang.org/en/latest/manual/missing/) for more 
 and illustrations about these rules. As noted above, they are generally consistent with
 those implemented by SQL's `NULL` and R's `NA`.
 
-## From `Nullable` to `missing` and `nothing`
+## From 'Nullable' to 'missing' and 'nothing'
 
 While it is similar to the previous `NA` value, the new `missing` object also replaces
 the `Nullable` type introduced in Julia 0.4, which turned out not to be the best choice
@@ -376,15 +390,17 @@ This efficient representation allows the compiler to generate very efficient cod
 processing arrays with missing values. For example, the following function is one of
 the most straightforward ways of computing the sum of non-missing values in an array:
 
-    function sum_nonmissing(X::AbstractArray)
-        s = zero(eltype(X))
-        @inbounds @simd for x in X
-            if x !== missing
-                s += x
-            end
+```julia
+function sum_nonmissing(X::AbstractArray)
+    s = zero(eltype(X))
+    @inbounds @simd for x in X
+        if x !== missing
+            s += x
         end
-        s
     end
+    s
+end
+```
 
 On Julia 0.7, this relatively naive implementation generates very efficient native
 code when the input is an `Array{Int}` object. In fact, thanks to masked
@@ -395,22 +411,24 @@ data but also potentially allows for the presence of `missing` values, and `X3` 
 contains 10% of `missing` values at random positions. `sum_nonmissing` takes about the
 same time for all three arrays (on an Intel Skylake CPU with AVX2 instructions enabled).
 
-    julia> X1 = rand(Int32, 10_000_000);
+```julia
+julia> X1 = rand(Int32, 10_000_000);
 
-    julia> X2 = Vector{Union{Missing, Int32}}(X1);
+julia> X2 = Vector{Union{Missing, Int32}}(X1);
 
-    julia> X3 = ifelse.(rand(length(X2)) .< 0.9, X2, missing);
+julia> X3 = ifelse.(rand(length(X2)) .< 0.9, X2, missing);
 
-    julia> using BenchmarkTools
+julia> using BenchmarkTools
 
-    julia> @btime sum_nonmissing(X1);
-      2.738 ms (1 allocation: 16 bytes)
+julia> @btime sum_nonmissing(X1);
+  2.738 ms (1 allocation: 16 bytes)
 
-    julia> @btime sum_nonmissing(X2);
-      3.216 ms (1 allocation: 16 bytes)
+julia> @btime sum_nonmissing(X2);
+  3.216 ms (1 allocation: 16 bytes)
 
-    julia> @btime sum_nonmissing(X3);
-      3.214 ms (1 allocation: 16 bytes)
+julia> @btime sum_nonmissing(X3);
+  3.214 ms (1 allocation: 16 bytes)
+```
 
 As a reference point, R's `sum(x, na.rm=TRUE)` function, which is implemented in C,
 takes about 7 ms without missing values and 19 ms with missing values (in R, `integer`
@@ -427,20 +445,22 @@ fast code like this in all situations. For example, missing values still have a
 significant performance impact for arrays of `Float64` elements, which are essential
 for numeric computing:
 
-    julia> Y1 = rand(10_000_000);
+```julia
+julia> Y1 = rand(10_000_000);
 
-    julia> Y2 = Vector{Union{Missing, Float64}}(Y1);
+julia> Y2 = Vector{Union{Missing, Float64}}(Y1);
 
-    julia> Y3 = ifelse.(rand(length(Y2)) .< 0.9, Y2, missing);
+julia> Y3 = ifelse.(rand(length(Y2)) .< 0.9, Y2, missing);
 
-    julia> @btime sum_nonmissing(Y1);
-      5.733 ms (1 allocation: 16 bytes)
+julia> @btime sum_nonmissing(Y1);
+  5.733 ms (1 allocation: 16 bytes)
 
-    julia> @btime sum_nonmissing(Y2);
-      13.854 ms (1 allocation: 16 bytes)
+julia> @btime sum_nonmissing(Y2);
+  13.854 ms (1 allocation: 16 bytes)
 
-    julia> @btime sum_nonmissing(Y3);
-      17.780 ms (1 allocation: 16 bytes)
+julia> @btime sum_nonmissing(Y3);
+  17.780 ms (1 allocation: 16 bytes)
+```
 
 However, this is nothing to be ashamed of, as Julia is still faster than R:
 `sum(x, na.rm=TRUE)` takes about 11 ms for a `numeric` array with no missing values,


### PR DESCRIPTION
Also update output when showing array, and drop backticks in headings since they currently give a really weird result (small font).

@ViralBShah Maybe there's a way to fix the font of code in backticks in headings? They currently look like this:
![capture d ecran de 2018-06-20 10-44-16](https://user-images.githubusercontent.com/1120448/41647576-08e3c24e-7477-11e8-8cc1-dc6e5b76d0c8.png)

