### PR TITLE
add redirect for utf8proc site

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,1 @@
+Redirect 301 /utf8proc/ http://juliastrings.github.io/utf8proc/

--- a/.htaccess
+++ b/.htaccess
@@ -1,1 +1,0 @@
-Redirect 301 /utf8proc/ http://juliastrings.github.io/utf8proc/

--- a/utf8proc/doc/index.html
+++ b/utf8proc/doc/index.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html><html><head>
+<meta http-equiv="refresh" content="0;url="http://juliastrings.github.io/utf8proc/doc/">
+</head></html>

--- a/utf8proc/index.html
+++ b/utf8proc/index.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html><html><head>
+<meta http-equiv="refresh" content="0;url="http://juliastrings.github.io/utf8proc/">
+</head></html>

--- a/utf8proc/releases/index.html
+++ b/utf8proc/releases/index.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html><html><head>
+<meta http-equiv="refresh" content="0;url="http://juliastrings.github.io/utf8proc/releases/">
+</head></html>


### PR DESCRIPTION
This adds a redirect for julialang.org/utf8proc (fixes #809) using an [htaccess file](https://mediatemple.net/community/products/grid/204643080/how-do-i-redirect-my-site-using-a-htaccess-file).

I have no idea how the julialang web server is configured.  Does it support `.htaccess` redirects like this?  @ararslan, do you know?